### PR TITLE
Added location resolver. Implemented only for field setting value.

### DIFF
--- a/Core/API/Handler/LocationResolverHandler.php
+++ b/Core/API/Handler/LocationResolverHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\Core\API\Handler;
+
+use Kaliop\eZMigrationBundle\Core\API\LocationResolver\LocationResolverInterface;
+
+class LocationResolverHandler
+{
+    /**
+     * @var LocationResolverInterface[]
+     */
+    private $resolvers;
+
+    /**
+     * @param LocationResolverInterface $resolver
+     */
+    public function addResolver(LocationResolverInterface $resolver)
+    {
+        $this->resolvers[] = $resolver;
+    }
+
+    /**
+     * @param string $identifier
+     * @return int
+     */
+    public function resolve($identifier)
+    {
+        foreach ($this->resolvers as $resolver) {
+            if ($resolver->shouldResolve($identifier)) {
+                return $resolver->resolve($identifier);
+            }
+        }
+
+        return $identifier;
+    }
+}

--- a/Core/API/LocationResolver/AbstractRepositoryAwareLocationResolver.php
+++ b/Core/API/LocationResolver/AbstractRepositoryAwareLocationResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\Core\API\LocationResolver;
+
+use eZ\Publish\API\Repository\Repository;
+
+abstract class AbstractRepositoryAwareLocationResolver implements LocationResolverInterface
+{
+    /**
+     * @var Repository
+     */
+    protected $repository;
+
+    /**
+     * AbstractRepositoryAwareLocationResolver constructor.
+     *
+     * @param Repository $repository
+     */
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+}

--- a/Core/API/LocationResolver/LocationRemoteIdLocationResolver.php
+++ b/Core/API/LocationResolver/LocationRemoteIdLocationResolver.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\Core\API\LocationResolver;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+class LocationRemoteIdLocationResolver extends AbstractRepositoryAwareLocationResolver
+{
+    /**
+     * @var string
+     */
+    private $remoteId;
+
+    /**
+     * Resolves reference to location id
+     *
+     * @param $reference
+     * @return int
+     * @throws \Exception
+     */
+    public function resolve($reference)
+    {
+        if (empty($this->remoteId)) {
+            throw new \Exception('Remote Id was not found, first check if reference should be resolved');
+        }
+
+        $location = $this->repository->getLocationService()->loadLocationByRemoteId($this->remoteId);
+
+        if (!$location instanceof Location) {
+            throw new \Exception(sprintf('Location with remote id "%s" not found', $this->remoteId));
+        }
+
+        return $location->id;
+    }
+
+    /**
+     * Tests if $reference should be resolved to location id
+     *
+     * @param $reference
+     * @return bool
+     */
+    public function shouldResolve($reference)
+    {
+        if (preg_match('/^location_remote_id:(.*)$/', $reference, $match)) {
+            $this->remoteId = $match[1];
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Core/API/LocationResolver/LocationResolverInterface.php
+++ b/Core/API/LocationResolver/LocationResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\Core\API\LocationResolver;
+
+interface LocationResolverInterface
+{
+    /**
+     * Resolves reference to location id
+     *
+     * @param $reference
+     * @return int
+     */
+    public function resolve($reference);
+
+    /**
+     * Tests if $reference should be resolved to location id
+     *
+     * @param $reference
+     * @return bool
+     */
+    public function shouldResolve($reference);
+}

--- a/Core/API/Managers/AbstractManager.php
+++ b/Core/API/Managers/AbstractManager.php
@@ -2,6 +2,7 @@
 
 namespace Kaliop\eZMigrationBundle\Core\API\Managers;
 
+use Kaliop\eZMigrationBundle\Core\API\Handler\LocationResolverHandler;
 use Kaliop\eZMigrationBundle\Core\API\ReferenceHandler;
 use Kaliop\eZMigrationBundle\Interfaces\API\ManagerInterface;
 use Kaliop\eZMigrationBundle\Interfaces\BundleAwareInterface;
@@ -151,9 +152,20 @@ abstract class AbstractManager implements ManagerInterface, ContainerAwareInterf
         return $referenceHandler->getReference($identifier);
     }
 
+    /**
+     * @return ContainerInterface
+     */
     public function getContainer()
     {
         return $this->container;
+    }
+
+    /**
+     * @return LocationResolverHandler
+     */
+    public function getLocationResolverHandler()
+    {
+        return $this->container->get('ez_migration_bundle.handler.location_resolver');
     }
 
     /**

--- a/Core/API/Managers/ContentTypeManager.php
+++ b/Core/API/Managers/ContentTypeManager.php
@@ -323,7 +323,7 @@ class ContentTypeManager extends AbstractManager
             $ret = array();
             foreach ($value as $key => $val)
             {
-                $ret[$key] = $val;
+                $ret[$key] = $this->parseFieldSettingValue($val);
                 if ( $this->isReference($val) )
                 {
                     $ret[$key] = $this->getReference($val);
@@ -336,6 +336,17 @@ class ContentTypeManager extends AbstractManager
         }
 
         return $ret;
+    }
+
+    /**
+     * Returns transformed value if needed
+     *
+     * @param $value
+     * @return mixed
+     */
+    private function parseFieldSettingValue($value)
+    {
+        return $this->getLocationResolverHandler()->resolve($value);
     }
 
     /**

--- a/DependencyInjection/CompilerPass/LocationResolverCompilerPass.php
+++ b/DependencyInjection/CompilerPass/LocationResolverCompilerPass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class LocationResolverCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('ez_migration_bundle.handler.location_resolver')) {
+            return;
+        }
+
+        $locationResolverHandler = $container->findDefinition('ez_migration_bundle.handler.location_resolver');
+        $locationResolvers = $container->findTaggedServiceIds('ez_migration_bundle.location_resolver');
+
+        foreach ($locationResolvers as $id => $tags) {
+            $locationResolverHandler->addMethodCall('addResolver', array(
+                new Reference($id)
+            ));
+        }
+    }
+}

--- a/EzMigrationBundle.php
+++ b/EzMigrationBundle.php
@@ -2,8 +2,16 @@
 
 namespace Kaliop\eZMigrationBundle;
 
+use Kaliop\eZMigrationBundle\DependencyInjection\CompilerPass\LocationResolverCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzMigrationBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        
+        $container->addCompilerPass(new LocationResolverCompilerPass());
+    }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,6 +7,9 @@ parameters:
   ez_migration_bundle.complex.field.ezbinaryfile.class: Kaliop\eZMigrationBundle\Core\API\ComplexFields\EzBinaryFile
   ez_migration_bundle.complex.field.ezxmltext.class: Kaliop\eZMigrationBundle\Core\API\ComplexFields\EzXmlText
   ez_migration_bundle.complex.field.ezpage.class: Kaliop\eZMigrationBundle\Core\API\ComplexFields\EzPage
+  ez_migration_bundle.handler.location_resolver.class: Kaliop\eZMigrationBundle\Core\API\Handler\LocationResolverHandler
+  ez_migration_bundle.location_resolver.repository_aware.class: Kaliop\eZMigrationBundle\Core\API\LocationResolver\AbstractRepositoryAwareLocationResolver
+  ez_migration_bundle.location_resolver.location_remote_id.class: Kaliop\eZMigrationBundle\Core\API\LocationResolver\LocationRemoteIdLocationResolver
 
 services:
   ez_migration_bundle.complex.field.manager:
@@ -25,3 +28,15 @@ services:
       - @ezpublish.api.repository
       - @service_container
       - %ezpublish.siteaccess.list%
+  ez_migration_bundle.handler.location_resolver:
+    class: %ez_migration_bundle.handler.location_resolver.class%
+  ez_migration_bundle.location_resolver.repository_aware:
+    class: %ez_migration_bundle.location_resolver.repository_aware.class%
+    abstract: true
+    arguments:
+      - @ezpublish.api.repository
+  ez_migration_bundle.location_resolver.location_remote_id:
+    class: %ez_migration_bundle.location_resolver.location_remote_id.class%
+    parent: ez_migration_bundle.location_resolver.repository_aware
+    tags:
+      - { name: ez_migration_bundle.location_resolver }


### PR DESCRIPTION
This PR adds the possibility to define location remote id for values in field settings. This can be easily extend by tagging services with `ez_migration_bundle.location_resolver` and implementing the `LocationResolverInterface` by them. It does not break the reference handler and is run just before. Later the reference handler could be refactored to `LocationResolver` and the places where value should be resolved as location.