### PR TITLE
add dedicated function to convert the reference matches to valid values

### DIFF
--- a/Core/Executor/LocationManager.php
+++ b/Core/Executor/LocationManager.php
@@ -39,19 +39,7 @@ class LocationManager extends RepositoryExecutor
             throw new \Exception('Missing parent location id. This is required to create the new location.');
         }
 
-        // convert the references passed in the match
-        // @todo probably can be moved to a separate method.
-        foreach ($match as $condition => $values) {
-            if (is_integer($values) && $this->isReference($values)) {
-                $match[$condition] = $this->getReference($values);
-            } elseif (is_array($values)) {
-                foreach ($values as $position => $value) {
-                    if ($this->isReference($value)) {
-                        $match[$condition][$position] = $this->getReference($value);
-                    }
-                }
-            }
-        }
+        $this->convertMatchReferences($match);
 
         $this->loginUser();
 
@@ -275,5 +263,25 @@ class LocationManager extends RepositoryExecutor
         }
 
         return true;
+    }
+
+    /**
+     * Convert the references to values
+     *
+     * @param $match
+     */
+    protected function convertMatchReferences(&$match)
+    {
+        foreach ($match as $condition => $values) {
+            if (!is_array($values) && $this->isReference($values)) {
+                $match[$condition] = $this->getReference($values);
+            } else {
+                foreach ($values as $position => $value) {
+                    if ($this->isReference($value)) {
+                        $match[$condition][$position] = $this->getReference($value);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
this fix a wrong check as remote ids can be strings. also a dedicated function has been created. param is passed by reference... don't know if you prefer a return instead....