### PR TITLE
Added support for language code

### DIFF
--- a/API/LanguageAwareInterface.php
+++ b/API/LanguageAwareInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\API;
+
+interface LanguageAwareInterface
+{
+    /**
+     * Injects language code, with xxx-YY format.
+     * e.g. fre-FR
+     *
+     * @param string $languageCode
+     */
+    public function setLanguageCode($languageCode);
+
+    /**
+     * @return string
+     */
+    public function getLanguageCode();
+
+    /**
+     * Sets default language code, with xxx-YY format.
+     * e.g. fre-FR
+     *
+     * @param string $languageCode
+     */
+    public function setDefaultLanguageCode($languageCode);
+
+    /**
+     * @return string
+     */
+    public function getDefaultLanguageCode();
+}

--- a/Command/MigrateCommand.php
+++ b/Command/MigrateCommand.php
@@ -33,6 +33,7 @@ class MigrateCommand extends AbstractCommand
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 "The directory or file to load the migration definitions from"
             )
+            ->addOption('default-language', null, InputOption::VALUE_REQUIRED, "Default language code that will be used if no language is provided in migration steps")
             ->addOption('ignore-failures', null, InputOption::VALUE_NONE, "Keep executing migrations even if one fails")
             ->addOption('clear-cache', null, InputOption::VALUE_NONE, "Clear the cache after the command finishes")
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, "Do not ask any interactive question")
@@ -147,7 +148,11 @@ EOT
             $output->writeln("<info>Processing $name</info>");
 
             try {
-                $migrationsService->executeMigration($migrationDefinition, !$input->getOption('no-transactions'));
+                $migrationsService->executeMigration(
+                    $migrationDefinition,
+                    !$input->getOption('no-transactions'),
+                    $input->getOption('default-language')
+                );
             } catch(\Exception $e) {
                 if ($input->getOption('ignore-failures')) {
                     $output->writeln("\n<error>Migration failed! Reason: " . $e->getMessage() . "</error>\n");

--- a/Core/Executor/ContentManager.php
+++ b/Core/Executor/ContentManager.php
@@ -85,8 +85,7 @@ class ContentManager extends RepositoryExecutor
         }
         $contentType = $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
 
-        // FIXME: Defaulting in language code for now
-        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, self::DEFAULT_LANGUAGE_CODE);
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $this->getLanguageCode());
         $this->setFields($contentCreateStruct, $this->dsl['attributes'], $contentType);
 
         if (array_key_exists('remote_id', $this->dsl)) {
@@ -246,7 +245,7 @@ class ContentManager extends RepositoryExecutor
                 $fieldValue = $this->getSingleFieldValue($field[$fieldIdentifier], $fieldType, $this->context);
             }
 
-            $createOrUpdateStruct->setField($fieldIdentifier, $fieldValue, self::DEFAULT_LANGUAGE_CODE);
+            $createOrUpdateStruct->setField($fieldIdentifier, $fieldValue, $this->getLanguageCode());
         }
     }
 

--- a/Core/Executor/ContentTypeManager.php
+++ b/Core/Executor/ContentTypeManager.php
@@ -36,20 +36,20 @@ class ContentTypeManager extends RepositoryExecutor
         $contentTypeGroup = $contentTypeService->loadContentTypeGroup($this->dsl['content_type_group']);
 
         $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct($this->dsl['identifier']);
-        $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE_CODE;
+        $contentTypeCreateStruct->mainLanguageCode = $this->getLanguageCode();
 
         // Object Name pattern
         $contentTypeCreateStruct->nameSchema = $this->dsl['name_pattern'];
 
         // set names for the content type
         $contentTypeCreateStruct->names = array(
-            self::DEFAULT_LANGUAGE_CODE => $this->dsl['name'],
+            $this->getLanguageCode() => $this->dsl['name'],
         );
 
         if (array_key_exists('description', $this->dsl)) {
             // set description for the content type
             $contentTypeCreateStruct->descriptions = array(
-                self::DEFAULT_LANGUAGE_CODE => $this->dsl['description'],
+                $this->getLanguageCode() => $this->dsl['description'],
             );
         }
 
@@ -97,19 +97,19 @@ class ContentTypeManager extends RepositoryExecutor
         $contentTypeDraft = $contentTypeService->createContentTypeDraft($contentType);
 
         $contentTypeUpdateStruct = $contentTypeService->newContentTypeUpdateStruct();
-        $contentTypeUpdateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE_CODE;
+        $contentTypeUpdateStruct->mainLanguageCode = $this->getLanguageCode();
 
         if (array_key_exists('new_identifier', $this->dsl)) {
             $contentTypeUpdateStruct->identifier = $this->dsl['new_identifier'];
         }
 
         if (array_key_exists('name', $this->dsl)) {
-            $contentTypeUpdateStruct->names = array(self::DEFAULT_LANGUAGE_CODE => $this->dsl['name']);
+            $contentTypeUpdateStruct->names = array($this->getLanguageCode() => $this->dsl['name']);
         }
 
         if (array_key_exists('description', $this->dsl)) {
             $contentTypeUpdateStruct->descriptions = array(
-                self::DEFAULT_LANGUAGE_CODE => $this->dsl['description'],
+                $this->getLanguageCode() => $this->dsl['description'],
             );
         }
 
@@ -249,10 +249,10 @@ class ContentTypeManager extends RepositoryExecutor
             if (!in_array($key, array('identifier', 'type'))) {
                 switch ($key) {
                     case 'name':
-                        $fieldDefinition->names = array(self::DEFAULT_LANGUAGE_CODE => $value);
+                        $fieldDefinition->names = array($this->getLanguageCode() => $value);
                         break;
                     case 'description':
-                        $fieldDefinition->descriptions = array(self::DEFAULT_LANGUAGE_CODE => $value);
+                        $fieldDefinition->descriptions = array($this->getLanguageCode() => $value);
                         break;
                     case 'required':
                         $fieldDefinition->isRequired = $value;
@@ -304,10 +304,10 @@ class ContentTypeManager extends RepositoryExecutor
                         $fieldDefinitionUpdateStruct->identifier = $value;
                         break;
                     case 'name':
-                        $fieldDefinitionUpdateStruct->names = array(self::DEFAULT_LANGUAGE_CODE => $value);
+                        $fieldDefinitionUpdateStruct->names = array($this->getLanguageCode() => $value);
                         break;
                     case 'description':
-                        $fieldDefinitionUpdateStruct->descriptions = array(self::DEFAULT_LANGUAGE_CODE => $value);
+                        $fieldDefinitionUpdateStruct->descriptions = array($this->getLanguageCode() => $value);
                         break;
                     case 'required':
                         $fieldDefinitionUpdateStruct->isRequired = $value;

--- a/Core/Executor/RepositoryExecutor.php
+++ b/Core/Executor/RepositoryExecutor.php
@@ -46,6 +46,13 @@ abstract class RepositoryExecutor extends AbstractExecutor
     protected $repository;
 
     /**
+     * Language code for current step.
+     *
+     * @var string
+     */
+    private $languageCode;
+
+    /**
      * The bundle object representing the bundle the currently processed migration is in.
      *
      * @var BundleInterface
@@ -87,6 +94,7 @@ abstract class RepositoryExecutor extends AbstractExecutor
 
         $this->dsl = $step->dsl;
         $this->context = $step->context;
+        $this->languageCode = isset($this->dsl['lang']) ? $this->dsl['lang'] : self::DEFAULT_LANGUAGE_CODE;
 
         if (method_exists($this, $action)) {
 
@@ -131,5 +139,15 @@ abstract class RepositoryExecutor extends AbstractExecutor
         }
 
         return $previousUser->id;
+    }
+
+    /**
+     * Returns selected language code.
+     *
+     * @return string
+     */
+    protected function getLanguageCode()
+    {
+        return $this->languageCode;
     }
 }

--- a/Core/Executor/RepositoryExecutor.php
+++ b/Core/Executor/RepositoryExecutor.php
@@ -2,6 +2,7 @@
 
 namespace Kaliop\eZMigrationBundle\Core\Executor;
 
+use Kaliop\eZMigrationBundle\API\LanguageAwareInterface;
 use Kaliop\eZMigrationBundle\API\ReferenceResolverInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Kaliop\eZMigrationBundle\API\Value\MigrationStep;
@@ -11,12 +12,10 @@ use \eZ\Publish\API\Repository\Repository;
 /**
  * The core manager class that all migration action managers inherit from.
  */
-abstract class RepositoryExecutor extends AbstractExecutor
+abstract class RepositoryExecutor extends AbstractExecutor implements LanguageAwareInterface
 {
     /**
      * Constant defining the default language code
-     *
-     * @todo inject via config parameter
      */
     const DEFAULT_LANGUAGE_CODE = 'eng-GB';
 
@@ -51,6 +50,11 @@ abstract class RepositoryExecutor extends AbstractExecutor
      * @var string
      */
     private $languageCode;
+
+    /**
+     * @var string
+     */
+    private $defaultLanguageCode;
 
     /**
      * The bundle object representing the bundle the currently processed migration is in.
@@ -94,7 +98,9 @@ abstract class RepositoryExecutor extends AbstractExecutor
 
         $this->dsl = $step->dsl;
         $this->context = $step->context;
-        $this->languageCode = isset($this->dsl['lang']) ? $this->dsl['lang'] : self::DEFAULT_LANGUAGE_CODE;
+        if (isset($this->dsl['lang'])) {
+            $this->setLanguageCode($this->dsl['lang']);
+        }
 
         if (method_exists($this, $action)) {
 
@@ -141,13 +147,23 @@ abstract class RepositoryExecutor extends AbstractExecutor
         return $previousUser->id;
     }
 
-    /**
-     * Returns selected language code.
-     *
-     * @return string
-     */
-    protected function getLanguageCode()
+    public function setLanguageCode($languageCode)
     {
-        return $this->languageCode;
+        $this->languageCode = $languageCode;
+    }
+
+    public function getLanguageCode()
+    {
+        return $this->languageCode ?: $this->getDefaultLanguageCode();
+    }
+
+    public function setDefaultLanguageCode($languageCode)
+    {
+        $this->defaultLanguageCode = $languageCode;
+    }
+
+    public function getDefaultLanguageCode()
+    {
+        return $this->defaultLanguageCode ?: self::DEFAULT_LANGUAGE_CODE;
     }
 }

--- a/Core/Executor/UserGroupManager.php
+++ b/Core/Executor/UserGroupManager.php
@@ -27,7 +27,7 @@ class UserGroupManager extends RepositoryExecutor
 
         $contentType = $this->repository->getContentTypeService()->loadContentTypeByIdentifier("user_group");
 
-        $userGroupCreateStruct = $userService->newUserGroupCreateStruct(self::DEFAULT_LANGUAGE_CODE, $contentType);
+        $userGroupCreateStruct = $userService->newUserGroupCreateStruct($this->getLanguageCode(), $contentType);
         $userGroupCreateStruct->setField('name', $this->dsl['name']);
 
         if (array_key_exists('description', $this->dsl)) {

--- a/Core/Executor/UserManager.php
+++ b/Core/Executor/UserManager.php
@@ -49,7 +49,7 @@ class UserManager extends RepositoryExecutor
             $this->dsl['username'],
             $this->dsl['email'],
             $this->dsl['password'],
-            self::DEFAULT_LANGUAGE_CODE,
+            $this->getLanguageCode(),
             $userContentType
         );
         $userCreateStruct->setField('first_name', $this->dsl['first_name']);

--- a/Core/ReferenceResolver/CustomReferenceResolver.php
+++ b/Core/ReferenceResolver/CustomReferenceResolver.php
@@ -30,7 +30,6 @@ class CustomReferenceResolver extends AbstractResolver
     {
         $identifier = $this->getReferenceIdentifier($identifier);
         if (!array_key_exists($identifier, $this->references)) {
-var_dump($this->references);
             throw new \Exception("No reference set with identifier '$identifier'");
         }
 

--- a/Core/ReferenceResolver/CustomReferenceResolver.php
+++ b/Core/ReferenceResolver/CustomReferenceResolver.php
@@ -45,10 +45,10 @@ class CustomReferenceResolver extends AbstractResolver
      */
     public function addReference($identifier, $value)
     {
-            if (array_key_exists($identifier, $this->references)) {
-                throw new \Exception("A reference with identifier '$identifier' already exists");
-            }
+        if (array_key_exists($identifier, $this->references)) {
+            throw new \Exception("A reference with identifier '$identifier' already exists");
+        }
 
-            $this->references[$identifier] = $value;
+        $this->references[$identifier] = $value;
     }
 }

--- a/Resources/doc/DSL/ManageContent.yml
+++ b/Resources/doc/DSL/ManageContent.yml
@@ -6,6 +6,7 @@
     priority: 0 # Set the priority of the main location
     other_locations: [x, y, z] # Optional, node ids of other parent location
     remote_id: custom_remote_id # Optional, will set an object remote id as the remote ID and a location remote ID with a _location suffix
+    lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     attributes:
         - attribute1: value1
         - attribute2: value2
@@ -56,6 +57,7 @@
         - parent_location_id: x # int|int[]
         - parent_location_remote_id: xxx # string|string[]
         - content_type: yyy # string|string[] a content type identifier
+    lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     attributes: # the list of attribute identifier value pairs
         - attribute1: value1
         - attribute2: value2

--- a/Resources/doc/DSL/ManageContentType.yml
+++ b/Resources/doc/DSL/ManageContentType.yml
@@ -8,6 +8,7 @@
     description: xyz # Optional
     url_name_pattern: pattern # Optional
     is_container: true|false # Optional, defaults to false
+    lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     attributes:
         -
             type: xyz # Attribute type (See list https://confluence.ez.no/display/EZP/FieldTypes)
@@ -40,6 +41,7 @@
     name_pattern: xyz # Optional, will be updated if set
     url_name_pattern: xyz # Optional, will be updated if set
     is_container: true|false # Optional, will be updated if set
+    lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     attributes: # Optional, if set will update existing ones or add new ones.
         -
             identifier: xyz # Identifier of the attribute to update or identifier of the new attribute to add

--- a/Resources/doc/DSL/ManageUsersAndGroups.yml
+++ b/Resources/doc/DSL/ManageUsersAndGroups.yml
@@ -6,7 +6,7 @@
     username: xyz
     email: xyz
     password: xyz
-    main_language: xyz # Optional, default to eng-GB
+    lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     groups: [x, y, z] # The user group ID or IDs (Object IDs) to put the user into
     # The list in references tells the manager to store specific values for later use
     # by other steps in the current migration.
@@ -64,6 +64,7 @@
     name: xyz # Optional
     description: xyz # Optional
     parent_group_id: x # Optional, the new parent user group ID
+    lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     # The list in references tells the manager to store specific values for later use
     # by other steps in the current migration.
     references: #Optional


### PR DESCRIPTION
This patch adds support for language code in migration steps:

```yaml
# Example for content creation
-
    type: content
    mode: create
    content_type: dossier
    main_location: 1234
    lang: fre-FR
    attributes:
        - titre: Some title
```

It also adds supports setting of a default language code to use, as a console command option, if no language is set in yml DSL:

```
php ezpublish/console kaliop:migration:migrate --default-language=fre-FR MyBundle
```