### PR TITLE
Typo in examples for role limitations

### DIFF
--- a/Resources/doc/DSL/ManageRolesAndPolicies.yml
+++ b/Resources/doc/DSL/ManageRolesAndPolicies.yml
@@ -58,14 +58,14 @@
         -
             module: xyz
             function: xyz # to grant access to all function, use '*' (including simple quotes)
-            limitation: # Optional
+            limitations: # Optional
                 -
                     identifier: xyz
                     values: [x, y]
         -
             module: xyz
             function: xyz
-            limitation:
+            limitations:
                 -
                     identifier: xyz
                     values: [x, y]
@@ -107,7 +107,7 @@
         -
             module: xyz
             function: xyz
-            limitation:
+            limitations:
                 -
                     identifier: xyz
                     values: [x, z]

--- a/Tests/dsl/good/UnitTestOK008_role.yml
+++ b/Tests/dsl/good/UnitTestOK008_role.yml
@@ -15,7 +15,7 @@
         -
             module: content
             function: create
-            limitation:
+            limitations:
                 -
                     identifier: Node
                     values: [ 2 ]
@@ -38,7 +38,7 @@
         -
             module: content
             function: read
-            limitation:
+            limitations:
                 -
                     identifier: Language
                     values: [eng-GB]


### PR DESCRIPTION
See https://github.com/kaliop-uk/ezmigrationbundle/blob/master/Core/Executor/RoleManager.php#L347

The key used is 'limitations' not 'limitation'