### PR TITLE
Fix handling of alwaysAvailable on content create

### DIFF
--- a/Core/Executor/ContentManager.php
+++ b/Core/Executor/ContentManager.php
@@ -64,6 +64,7 @@ class ContentManager extends RepositoryExecutor
         if (isset($this->dsl['always_available'])) {
             $contentCreateStruct->alwaysAvailable = $this->dsl['always_available'];
         } else {
+            // Can be removed when https://github.com/kaliop-uk/ezmigrationbundle/pull/88 is merged
             $contentCreateStruct->alwaysAvailable = $contentType->defaultAlwaysAvailable;
         }
 

--- a/Core/Executor/ContentManager.php
+++ b/Core/Executor/ContentManager.php
@@ -61,6 +61,12 @@ class ContentManager extends RepositoryExecutor
 
         $this->setFields($contentCreateStruct, $this->dsl['attributes'], $contentType);
 
+        if (isset($this->dsl['always_available'])) {
+            $contentCreateStruct->alwaysAvailable = $this->dsl['always_available'];
+        } else {
+            $contentCreateStruct->alwaysAvailable = $contentType->defaultAlwaysAvailable;
+        }
+
         if (isset($this->dsl['remote_id'])) {
             $contentCreateStruct->remoteId = $this->dsl['remote_id'];
         }

--- a/Core/Executor/ContentTypeManager.php
+++ b/Core/Executor/ContentTypeManager.php
@@ -73,6 +73,10 @@ class ContentTypeManager extends RepositoryExecutor
             $contentTypeCreateStruct->isContainer = $this->dsl['is_container'];
         }
 
+        if (isset($this->dsl['default_always_available'])) {
+            $contentTypeCreateStruct->defaultAlwaysAvailable = $this->dsl['default_always_available'];
+        }
+
         // Add attributes
         foreach ($this->dsl['attributes'] as $position => $attribute) {
             $fieldDefinition = $this->createFieldDefinition($contentTypeService, $attribute);

--- a/Resources/doc/DSL/ManageContent.yml
+++ b/Resources/doc/DSL/ManageContent.yml
@@ -16,6 +16,7 @@
     version_creator: yyy # user id, login or email if unique; Optional, set the creator of the 1st version
     modification_date: zzz # Optional, set content modification date (if integer: timestamp is assumed. if string, see: http://php.net/manual/en/datetime.formats.php)
     publication_date: zzz # Optional, set content publication date (if integer: timstamp is assumed. if string, see: http://php.net/manual/en/datetime.formats.php)
+    always_available: true|false # Optional, will default to content type defaultAlwaysAvailable
     attributes:
         attribute1: value1
         attribute2: value2

--- a/Resources/doc/DSL/ManageContentType.yml
+++ b/Resources/doc/DSL/ManageContentType.yml
@@ -9,6 +9,7 @@
     url_name_pattern: pattern # Optional
     is_container: true|false # Optional, defaults to false
     lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
+    default_always_available: true|false # Optional, defaults to true
     attributes:
         -
             type: xyz # Attribute type (See list https://doc.ez.no/display/EZP/FieldTypes+reference)

--- a/Tests/dsl/good/UnitTestOK003_contentType.yml
+++ b/Tests/dsl/good/UnitTestOK003_contentType.yml
@@ -8,6 +8,7 @@
     identifier: kmb_test_1
     description: Kaliop Migration Bundle Test Class 1
     name_pattern: <title>
+    default_always_available: true
     attributes:
         -
             type: ezstring

--- a/Tests/dsl/good/UnitTestOK004_content.yml
+++ b/Tests/dsl/good/UnitTestOK004_content.yml
@@ -8,6 +8,7 @@
     name: Kaliop Migration Bundle Test Class 2
     name_pattern: '<ezstring>'
     is_container: true
+    always_available: true
     attributes:
         -
             type: ezstring


### PR DESCRIPTION
When adding content alwaysAvailable is not respecting the content type default.  This allow setting alwaysAvailable or falling back to the default from the content type.