### PR TITLE
Allowing remote_id for user group related migrations

### DIFF
--- a/Core/Matcher/ContentMatcher.php
+++ b/Core/Matcher/ContentMatcher.php
@@ -56,7 +56,7 @@ class ContentMatcher extends RepositoryMatcher
 
             // BC support
             if ($key == 'content_type') {
-                if (is_int($key) || ctype_digit($key)) {
+                if (ctype_digit($key)) {
                     $key = self::MATCH_CONTENT_TYPE_ID;
                 } else {
                     $key = self::MATCH_CONTENT_TYPE_IDENTIFIER;

--- a/Core/Matcher/UserGroupMatcher.php
+++ b/Core/Matcher/UserGroupMatcher.php
@@ -99,6 +99,8 @@ class UserGroupMatcher extends RepositoryMatcher implements KeyMatcherInterface
 
         foreach ($remoteContentIds as $remoteContentId) {
             // return unique contents
+
+            // user service does not provide a method to load user groups via remote_id, but as user groups are content...
             $content = $this->repository->getContentService()->loadContentByRemoteId($remoteContentId);
             $userGroup = $this->repository->getUserService()->loadUserGroup($content->id);
 

--- a/Core/Matcher/UserGroupMatcher.php
+++ b/Core/Matcher/UserGroupMatcher.php
@@ -14,9 +14,11 @@ class UserGroupMatcher extends RepositoryMatcher implements KeyMatcherInterface
     use FlexibleKeyMatcherTrait;
 
     const MATCH_USERGROUP_ID = 'usergroup_id';
+    const MATCH_CONTENT_REMOTE_ID = 'content_remote_id';
 
     protected $allowedConditions = array(
         self::MATCH_USERGROUP_ID,
+        self::MATCH_CONTENT_REMOTE_ID,
         // aliases
         'id'
     );
@@ -48,14 +50,25 @@ class UserGroupMatcher extends RepositoryMatcher implements KeyMatcherInterface
             switch ($key) {
                 case 'id':
                 case self::MATCH_USERGROUP_ID:
-                   return new UserGroupCollection($this->findUserGroupsById($values));
+                    return new UserGroupCollection($this->findUserGroupsById($values));
+                case self::MATCH_CONTENT_REMOTE_ID:
+                    return new UserGroupCollection($this->findUserGroupsByContentRemoteIds($values));
+
             }
         }
     }
 
+    /**
+     * When matching by key, we accept user group Id and it's remote Id only
+     * @param int|string $key
+     * @return array
+     */
     protected function getConditionsFromKey($key)
     {
-        return array(self::MATCH_USERGROUP_ID => $key);
+        if (is_int($key) || ctype_digit($key)) {
+            return array(self::MATCH_USERGROUP_ID => $key);
+        }
+        return array(self::MATCH_CONTENT_REMOTE_ID => $key);
     }
 
     /**
@@ -69,6 +82,25 @@ class UserGroupMatcher extends RepositoryMatcher implements KeyMatcherInterface
         foreach ($userGroupIds as $userGroupId) {
             // return unique contents
             $userGroup = $this->repository->getUserService()->loadUserGroup($userGroupId);
+
+            $userGroups[$userGroup->id] = $userGroup;
+        }
+
+        return $userGroups;
+    }
+
+    /**
+     * @param string[] $remoteContentIds
+     * @return UserGroup[]
+     */
+    protected function findUserGroupsByContentRemoteIds(array $remoteContentIds)
+    {
+        $userGroups = [];
+
+        foreach ($remoteContentIds as $remoteContentId) {
+            // return unique contents
+            $content = $this->repository->getContentService()->loadContentByRemoteId($remoteContentId);
+            $userGroup = $this->repository->getUserService()->loadUserGroup($content->id);
 
             $userGroups[$userGroup->id] = $userGroup;
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -208,6 +208,7 @@ services:
         class: '%ez_migration_bundle.executor.user_manager.class%'
         arguments:
             - '@ez_migration_bundle.user_matcher'
+            - '@ez_migration_bundle.user_group_matcher'
         tags:
             - { name: ez_migration_bundle.executor }
 

--- a/Resources/doc/DSL/ManageUsersAndGroups.yml
+++ b/Resources/doc/DSL/ManageUsersAndGroups.yml
@@ -7,7 +7,7 @@
     email: xyz
     password: xyz
     lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
-    groups: [x, y, z] # The user group ID or IDs (Content IDs) to put the user into
+    groups: [x, y, z] # The user group ID or IDs (Content IDs or it's remote_ids as string) to put the user into
     # The list in references tells the manager to store specific values for later use
     # by other steps in the current migration.
     references: # Optional
@@ -26,7 +26,7 @@
     email: xyz # Optional. NB: can only be set if the match definition latches a single user
     password: xyz # Optional
     enabled: true|false # Optional
-    # Optional, Group ID / list of group IDs the user has to be a member of.
+    # Optional, Group ID / list of group IDs (or it's remote_ids) the user has to be a member of.
     # The user will be removed from all groups that are not in the list
     groups: [x, y, z]
     # The list in references tells the manager to store specific values for later use by other steps in the current migration.
@@ -48,7 +48,7 @@
 -
     type: user_group
     mode: create
-    parent_group_id: x # The content ID of the user group to put the new group into, can be an array
+    parent_group_id: x # The content ID of the user group to put the new group into, can be an array. Content remote_id also supported.
     name: xyz
     description: xyz # Optional
     roles: [x, y, z] # The role names or ids to assign to the group
@@ -65,9 +65,10 @@
     mode: update
     match: # Define which groups to update
         - id: x # int|int[]
+        - content_remote_id: y # int|int[]
     name: xyz # Optional. Can only be used when the group to be updted is single
     description: xyz # Optional
-    parent_group_id: x # Optional, the new parent user group ID
+    parent_group_id: x # Optional, the new parent user group ID or group's remote_id
     lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)
     # The list in references tells the manager to store specific values for later use by other steps in the current migration.
     # NB: these are NEW VARIABLES THAT YOU ARE CREATING. They are not used in the current migration step!
@@ -83,3 +84,4 @@
     mode: delete
     match: # Only one of the following can be specified, to define which groups to delete
         - id: x # int|int[]
+        - content_remote_id: y # int|int[]


### PR DESCRIPTION
As in our project we do not want to rely on autoincrement id's related to user group migrations (e.g. as resorting might break migrations), we enhanced the existing migration possibilities for user groups to allow usage of remote_id for:
- user group's "parent_group_id": if string provided, it is considered referencing a user group's remote_id instead of it's id
- allowing matching on "content_remote_id" for user group update/delete 
- allowing usage of user group remote_id in user's "groups" when creating/updating

I hope this PR work is acceptable, otherwise I am open to improvement ideas and suggestions. Did not find any unit tests to enhance or adapt, tested running several migrations using the new possibilities though.