### PR TITLE
Extend GenerateCommand to generate migration for existing content types

### DIFF
--- a/API/MigrationGeneratorInterface.php
+++ b/API/MigrationGeneratorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\API;
+
+/**
+ * Interface that all migration definition handlers need to implement if they can generate a migration.
+ */
+interface MigrationGeneratorInterface
+{
+    /**
+     * Generate a migration
+     *
+     * @param string $identifier
+     * @param string $mode
+     * @return array Migration data
+     * @throws \Exception
+     */
+    public function generateMigration($identifier, $mode);
+}

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -9,12 +9,17 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
  */
 abstract class AbstractCommand extends ContainerAwareCommand
 {
+    /**
+     * @var \Kaliop\eZMigrationBundle\Core\MigrationService
+     */
     private $migrationService;
 
+    /**
+     * @return \Kaliop\eZMigrationBundle\Core\MigrationService
+     */
     public function getMigrationService()
     {
-        if (!$this->migrationService)
-        {
+        if (!$this->migrationService) {
             $this->migrationService = $this->getContainer()->get('ez_migration_bundle.migration_service');
         }
 

--- a/Core/MigrationService.php
+++ b/Core/MigrationService.php
@@ -66,6 +66,20 @@ class MigrationService
     }
 
     /**
+     * @param string $type
+     * @return ExecutorInterface
+     * @throws \InvalidArgumentException If executor doesn't exist
+     */
+    public function getExecutor($type)
+    {
+        if (!isset($this->executors[$type])) {
+            throw new \InvalidArgumentException("Executor with type '$type' doesn't exist");
+        }
+
+        return $this->executors[$type];
+    }
+
+    /**
      * NB: returns UNPARSED definitions
      *
      * @param string[] $paths

--- a/Tests/phpunit/1_GenerateTest.php
+++ b/Tests/phpunit/1_GenerateTest.php
@@ -7,51 +7,57 @@ use Symfony\Component\Console\Input\ArrayInput;
 class GenerateTest extends CommandTest
 {
     /**
-     * @todo add tests for generating a 'role' migration
+     * @dataProvider provideGenerateParameters
      */
-    public function testGenerateDSL()
+    public function testGenerateDSL($name, $format, $type, $identifier, $mode)
     {
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle));
-        $exitCode = $this->app->run($input, $this->output);
-        $output = $this->fetchOutput();
-        $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->checkGeneratedFile($this->saveGeneratedFile($output));
+        $parameters = array(
+            'command' => 'kaliop:migration:generate',
+            'bundle' => $this->targetBundle
+        );
 
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle, '--format' => 'sql'));
-        $exitCode = $this->app->run($input, $this->output);
-        $output = $this->fetchOutput();
-        $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->checkGeneratedFile($this->saveGeneratedFile($output));
+        if ($name) {
+            $parameters['name'] = $name;
+        }
 
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle, '--format' => 'php'));
-        $exitCode = $this->app->run($input, $this->output);
-        $output = $this->fetchOutput();
-        $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->checkGeneratedFile($this->saveGeneratedFile($output));
+        if ($format) {
+            $parameters['--format'] = $format;
+        }
 
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle, 'name' => 'unit_test_generated'));
-        $exitCode = $this->app->run($input, $this->output);
-        $output = $this->fetchOutput();
-        $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->checkGeneratedFile($this->saveGeneratedFile($output));
+        if ($type) {
+            $parameters['--type'] = $type;
+        }
 
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle, 'name' => 'unit_test_generated', '--format' => 'sql'));
-        $exitCode = $this->app->run($input, $this->output);
-        $output = $this->fetchOutput();
-        $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->checkGeneratedFile($this->saveGeneratedFile($output));
+        if ($identifier) {
+            $parameters['--identifier'] = $identifier;
+        }
 
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle, 'name' => 'unit_test_generated', '--format' => 'php'));
-        $exitCode = $this->app->run($input, $this->output);
-        $output = $this->fetchOutput();
-        $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->checkGeneratedFile($this->saveGeneratedFile($output));
+        if ($mode) {
+            $parameters['--mode'] = $mode;
+        }
 
-        $input = new ArrayInput(array('command' => 'kaliop:migration:generate', 'bundle' => $this->targetBundle, 'name' => 'unit_test_generated_role', '--role' => 'Anonymous'));
+        $input = new ArrayInput($parameters);
         $exitCode = $this->app->run($input, $this->output);
         $output = $this->fetchOutput();
         $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
         $this->checkGeneratedFile($this->saveGeneratedFile($output));
+    }
+
+    public function provideGenerateParameters()
+    {
+        return array(
+            array(null, null, null, null, null),
+            array(null, 'sql', null, null, null),
+            array(null, 'php', null, null, null),
+            array('unit_test_generated', null, null, null, null),
+            array('unit_test_generated', 'sql', null, null, null),
+            array('unit_test_generated', 'php', null, null, null),
+            array('unit_test_generated_role', null, 'role', 'Anonymous', null),
+            array('unit_test_generated_role', null, 'role', 'Anonymous', 'create'),
+            array('unit_test_generated_role', null, 'role', 'Anonymous', 'update'),
+            array('unit_test_generated_content_type', 'yml', 'content_type', 'folder', null),
+            array('unit_test_generated_content_type', 'json', 'content_type', 'folder', 'update')
+        );
     }
 
     protected function saveGeneratedFile($output)
@@ -70,6 +76,6 @@ class GenerateTest extends CommandTest
         $exitCode = $this->app->run($input, $this->output);
         $output = $this->fetchOutput();
         $this->assertSame(0, $exitCode, 'CLI Command failed. Output: ' . $output);
-        $this->assertRegExp('?\| ' . basename($filePath) . ' +\| not executed +\|?', $output );
+        $this->assertRegExp('?\| ' . basename($filePath) . ' +\| not executed +\|?', $output);
     }
 }

--- a/Tests/phpunit/CommandTest.php
+++ b/Tests/phpunit/CommandTest.php
@@ -11,6 +11,9 @@ abstract class CommandTest extends WebTestCase
     protected $leftovers = array();
 
     protected $container;
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Console\Application
+     */
     protected $app;
     protected $output;
 


### PR DESCRIPTION
Is a part of issue: https://github.com/kaliop-uk/ezmigrationbundle/issues/34
Requires: https://github.com/ezsystems/ezpublish-kernel/pull/1893