### PR TITLE
Extend GenerateCommand to generate migration for existing contents

### DIFF
--- a/API/Collection/AbstractCollection.php
+++ b/API/Collection/AbstractCollection.php
@@ -15,9 +15,9 @@ class AbstractCollection extends \ArrayObject
      * @param int $flags
      * @param string $iterator_class
      */
-    public function __construct ($input = array(), $flags = 0, $iterator_class = "ArrayIterator")
+    public function __construct($input = array(), $flags = 0, $iterator_class = "ArrayIterator")
     {
-        foreach($input as $value) {
+        foreach ($input as $value) {
             if (!is_a($value, $this->allowedClass)) {
                 $this->throwInvalid($value);
             }
@@ -29,22 +29,22 @@ class AbstractCollection extends \ArrayObject
     /**
      * @param mixed $value
      */
-    public function append ($value)
+    public function append($value)
     {
         if (!is_a($value, $this->allowedClass)) {
             $this->throwInvalid($value);
         }
 
-        return parent::append($value);
+        parent::append($value);
     }
 
     /**
      * @param mixed $input
      * @return array the old array
      */
-    public function exchangeArray ($input)
+    public function exchangeArray($input)
     {
-        foreach($input as $value) {
+        foreach ($input as $value) {
             if (!is_a($value, $this->allowedClass)) {
                 $this->throwInvalid($value);
             }
@@ -57,13 +57,13 @@ class AbstractCollection extends \ArrayObject
      * @param mixed $index
      * @param mixed $newval
      */
-    public function offsetSet ($index , $newval)
+    public function offsetSet($index, $newval)
     {
         if (!is_a($newval, $this->allowedClass)) {
             $this->throwInvalid($newval);
         }
 
-        return parent::offsetSet($index , $newval);
+        parent::offsetSet($index, $newval);
     }
 
     protected function throwInvalid($newval)

--- a/API/LoaderInterface.php
+++ b/API/LoaderInterface.php
@@ -9,7 +9,7 @@ interface LoaderInterface
 {
     /**
      * @param array $paths either dir names or file names
-     * @return string[] migrations definitions. key: name, value: path
+     * @return \Kaliop\eZMigrationBundle\API\Value\MigrationDefinition[] migrations definitions. key: name, value: path
      * @throws \Exception
      */
     public function listAvailableDefinitions(array $paths = array());

--- a/API/MatcherInterface.php
+++ b/API/MatcherInterface.php
@@ -8,7 +8,7 @@ interface MatcherInterface
      * Returns an array of items, or an array-like object, whith all items which satisfy the conditions $conditions
      *
      * @param array $conditions
-     * @return array|ArrayObject
+     * @return array|\ArrayObject
      */
     public function match(array $conditions);
 

--- a/API/MigrationGeneratorInterface.php
+++ b/API/MigrationGeneratorInterface.php
@@ -10,10 +10,11 @@ interface MigrationGeneratorInterface
     /**
      * Generate a migration
      *
-     * @param string $identifier
+     * @param string $matchType
+     * @param string $matchValue
      * @param string $mode
      * @return array Migration data
      * @throws \Exception
      */
-    public function generateMigration($identifier, $mode);
+    public function generateMigration($matchType, $matchValue, $mode);
 }

--- a/API/StorageHandlerInterface.php
+++ b/API/StorageHandlerInterface.php
@@ -47,7 +47,7 @@ interface StorageHandlerInterface
      * @param bool $force When true, the migration will be updated even if it was not in 'started' status
      * @throws \Exception If the migration was not started (unless $force=true)
      */
-    public function endMigration(Migration $migration, $force=false);
+    public function endMigration(Migration $migration, $force = false);
 
     /**
      * Removes a migration from storage (regardless of its status)

--- a/API/Value/Migration.php
+++ b/API/Value/Migration.php
@@ -29,12 +29,12 @@ class Migration extends AbstractValue
 
     /**
      * @param string $name
-     * @param string md5 checksum of the migration definition file
+     * @param string $md5 checksum of the migration definition file
      * @param string $path
      * @param int $executionDate timestamp
      * @param int $status
      */
-    function __construct($name, $md5, $path, $executionDate = null, $status = 0, $executionError = null)
+    public function __construct($name, $md5, $path, $executionDate = null, $status = 0, $executionError = null)
     {
         $this->name = $name;
         $this->md5 = $md5;

--- a/API/Value/MigrationDefinition.php
+++ b/API/Value/MigrationDefinition.php
@@ -33,7 +33,7 @@ class MigrationDefinition extends AbstractValue
      * @param MigrationStep[] $steps
      * @param string $parsingError
      */
-    function __construct($name, $path, $rawDefinition, $status = 0, array $steps=array(), $parsingError = null)
+    public function __construct($name, $path, $rawDefinition, $status = 0, array $steps = array(), $parsingError = null)
     {
         $this->name = $name;
         $this->path = $path;

--- a/API/Value/MigrationStep.php
+++ b/API/Value/MigrationStep.php
@@ -13,7 +13,7 @@ class MigrationStep extends AbstractValue
     protected $dsl;
     protected $context;
 
-    function __construct($type, array $dsl = array(), array $context = array())
+    public function __construct($type, array $dsl = array(), array $context = array())
     {
         $this->type = $type;
         $this->dsl = $dsl;

--- a/Command/MigrateCommand.php
+++ b/Command/MigrateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Kaliop\eZMigrationBundle\Command;
 
+use Kaliop\eZMigrationBundle\Core\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -10,7 +11,6 @@ use Kaliop\eZMigrationBundle\API\Value\MigrationDefinition;
 use Kaliop\eZMigrationBundle\API\Value\Migration;
 use Symfony\Component\Process\ProcessBuilder;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Symfony\Component\Process\Process;
 
 /**
  * Command to execute the available migration definitions.
@@ -23,7 +23,7 @@ class MigrateCommand extends AbstractCommand
     protected $output;
     protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
-    const COMMAND_NAME='kaliop:migration:migrate';
+    const COMMAND_NAME = 'kaliop:migration:migrate';
 
     /**
      * Set up the command.
@@ -114,15 +114,15 @@ EOT
             // 'optional' options
             // note: options 'clear-cache', 'ignore-failures' and 'no-transactions' we never propagate
             if ($input->getOption('default-language')) {
-                $builderArgs[]='--default-language='.$input->getOption('default-language');
+                $builderArgs[] = '--default-language=' . $input->getOption('default-language');
             }
             if ($input->getOption('no-transactions')) {
-                $builderArgs[]='--no-transactions';
+                $builderArgs[] = '--no-transactions';
             }
         }
 
         /** @var MigrationDefinition $migrationDefinition */
-        foreach($toExecute as $name => $migrationDefinition) {
+        foreach ($toExecute as $name => $migrationDefinition) {
 
             // let's skip migrations that we know are invalid - user was warned and he decided to proceed anyway
             if ($migrationDefinition->status == MigrationDefinition::STATUS_INVALID) {
@@ -144,7 +144,7 @@ EOT
                 $process->setTimeout(86400);
                 // and give immediate feedback to the user
                 $process->run(
-                    function ($type, $buffer) {
+                    function($type, $buffer) {
                         echo $buffer;
                     }
                 );
@@ -176,7 +176,7 @@ EOT
                         throw new \Exception($errorMsg);
                     }
 
-                } catch(\Exception $e) {
+                } catch (\Exception $e) {
                     if ($input->getOption('ignore-failures')) {
                         $output->writeln("\n<error>Migration failed! Reason: " . $e->getMessage() . "</error>\n");
                         continue;
@@ -193,7 +193,7 @@ EOT
                         !$input->getOption('no-transactions'),
                         $input->getOption('default-language')
                     );
-                } catch(\Exception $e) {
+                } catch (\Exception $e) {
                     if ($input->getOption('ignore-failures')) {
                         $output->writeln("\n<error>Migration failed! Reason: " . $e->getMessage() . "</error>\n");
                         continue;
@@ -215,20 +215,20 @@ EOT
     }
 
     /**
-     * @param string $paths
-     * @param $migrationService
+     * @param string[] $paths
+     * @param MigrationService $migrationService
      * @return MigrationDefinition[]
      *
      * @todo this does not scale well with many definitions or migrations
      */
-    protected function buildMigrationsList($paths, $migrationService)
+    protected function buildMigrationsList($paths, MigrationService $migrationService)
     {
         $migrationDefinitions = $migrationService->getMigrationsDefinitions($paths);
         $migrations = $migrationService->getMigrations();
 
         // filter away all migrations except 'to do' ones
         $toExecute = array();
-        foreach($migrationDefinitions as $name => $migrationDefinition) {
+        foreach ($migrationDefinitions as $name => $migrationDefinition) {
             if (!isset($migrations[$name]) || (($migration = $migrations[$name]) && $migration->status == Migration::STATUS_TODO)) {
                 $toExecute[$name] = $migrationService->parseMigrationDefinition($migrationDefinition);
             }
@@ -262,11 +262,11 @@ EOT
      *
      * @todo use a more compact output when there are *many* migrations
      */
-    protected function printMigrationsList($toExecute , InputInterface $input, OutputInterface $output)
+    protected function printMigrationsList($toExecute, InputInterface $input, OutputInterface $output)
     {
         $data = array();
         $i = 1;
-        foreach($toExecute as $name => $migrationDefinition) {
+        foreach ($toExecute as $name => $migrationDefinition) {
             $notes = '';
             if ($migrationDefinition->status != MigrationDefinition::STATUS_PARSED) {
                 $notes = '<error>' . $migrationDefinition->parsingError . '</error>';
@@ -314,7 +314,7 @@ EOT
      * @param $message
      * @param int $verbosity
      */
-    protected function writeln($message, $verbosity=OutputInterface::VERBOSITY_NORMAL)
+    protected function writeln($message, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
         if ($this->verbosity >= $verbosity) {
             $this->output->writeln($message);

--- a/Command/MigrationCommand.php
+++ b/Command/MigrationCommand.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Kaliop\eZMigrationBundle\Command;
+
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -50,7 +51,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (! $input->getOption('add') && ! $input->getOption('delete') && ! $input->getOption('skip')) {
+        if (!$input->getOption('add') && !$input->getOption('delete') && !$input->getOption('skip')) {
             throw new \InvalidArgumentException('You must specify whether you want to --add, --delete or --skip the specified migration.');
         }
 
@@ -80,7 +81,7 @@ EOT
                 throw new \InvalidArgumentException(sprintf('The path "%s" does not correspond to any migration definition.', $migrationNameOrPath));
             }
 
-            foreach($migrationDefinitionCollection as $migrationDefinition) {
+            foreach ($migrationDefinitionCollection as $migrationDefinition) {
                 $migrationName = basename($migrationDefinition->path);
 
                 $migration = $migrationService->getMigration($migrationNameOrPath);
@@ -115,7 +116,7 @@ EOT
                 throw new \InvalidArgumentException(sprintf('The path "%s" does not correspond to any migration definition.', $migrationNameOrPath));
             }
 
-            foreach($migrationDefinitionCollection as $migrationDefinition) {
+            foreach ($migrationDefinitionCollection as $migrationDefinition) {
                 $migrationService->skipMigration($migrationDefinition);
                 $output->writeln('<info>Migration' . $migrationDefinition->path . ' marked as skipped</info>');
             }

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -41,7 +41,7 @@ EOT
     {
         $migrationsService = $this->getMigrationService();
 
-        $migrationDefinitions = $migrationsService->getMigrationsDefinitions($input->getOption('path')) ;
+        $migrationDefinitions = $migrationsService->getMigrationsDefinitions($input->getOption('path'));
         $migrations = $migrationsService->getMigrations();
 
         if (!count($migrationDefinitions) && !count($migrations)) {
@@ -51,10 +51,10 @@ EOT
 
         // create a unique ist of all migrations (coming from db) and definitions (coming from disk)
         $index = array();
-        foreach($migrationDefinitions as $migrationDefinition) {
+        foreach ($migrationDefinitions as $migrationDefinition) {
             $index[$migrationDefinition->name] = array('definition' => $migrationDefinition);
         }
-        foreach($migrations as $migration) {
+        foreach ($migrations as $migration) {
             if (isset($index[$migration->name])) {
                 $index[$migration->name]['migration'] = $migration;
             } else {
@@ -64,11 +64,10 @@ EOT
                 if ($migration->path != '' && is_file($migration->path)) {
                     try {
                         $migrationDefinitionCollection = $migrationsService->getMigrationsDefinitions(array($migration->path));
-                        if (count($migrationDefinitionCollection))
-                        {
+                        if (count($migrationDefinitionCollection)) {
                             $index[$migration->name]['definition'] = reset($migrationDefinitionCollection);
                         }
-                    } catch(\Exception $e) {
+                    } catch (\Exception $e) {
                         /// @todo one day we should be able to limit the kind of exceptions we have to catch here...
                     }
                 }
@@ -80,7 +79,7 @@ EOT
 
         $data = array();
         $i = 1;
-        foreach($index as $name => $value) {
+        foreach ($index as $name => $value) {
             if (!isset($value['migration'])) {
                 $migrationDefinition = $migrationsService->parseMigrationDefinition($value['definition']);
                 $notes = '';

--- a/Core/ComplexField/ComplexFieldManager.php
+++ b/Core/ComplexField/ComplexFieldManager.php
@@ -21,7 +21,7 @@ class ComplexFieldManager
      * @param string $fieldTypeIdentifier
      * @param string $contentTypeIdentifier
      */
-    public function addComplexField(ComplexFieldInterface $complexField, $fieldTypeIdentifier, $contentTypeIdentifier=null)
+    public function addComplexField(ComplexFieldInterface $complexField, $fieldTypeIdentifier, $contentTypeIdentifier = null)
     {
         if ($contentTypeIdentifier == null) {
             $contentTypeIdentifier = '*';
@@ -30,7 +30,7 @@ class ComplexFieldManager
     }
 
     /**
-     * @param $fieldTypeIdentifier
+     * @param string $fieldTypeIdentifier
      * @param string $contentTypeIdentifier
      * @return bool
      */
@@ -49,15 +49,14 @@ class ComplexFieldManager
      */
     public function getComplexFieldValue($fieldTypeIdentifier, $contentTypeIdentifier, $fieldValue, array $context = array())
     {
-        if (isset($this->fieldTypeMap[$contentTypeIdentifier][$fieldTypeIdentifier]) || isset($this->fieldTypeMap['*'][$fieldTypeIdentifier]))
-        {
-            $fieldService = isset($this->fieldTypeMap[$contentTypeIdentifier][$fieldTypeIdentifier]) ?
-                $this->fieldTypeMap[$contentTypeIdentifier][$fieldTypeIdentifier] :
-                $this->fieldTypeMap['*'][$fieldTypeIdentifier];
-            return $fieldService->createValue($fieldValue, $context);
-        }
-        else
-        {
+        if ($this->managesField($fieldTypeIdentifier, $contentTypeIdentifier)) {
+            if (isset($this->fieldTypeMap[$contentTypeIdentifier][$fieldTypeIdentifier])) {
+                $fieldType = $this->fieldTypeMap[$contentTypeIdentifier][$fieldTypeIdentifier];
+            } else {
+                $fieldType = $this->fieldTypeMap['*'][$fieldTypeIdentifier];
+            }
+            return $fieldType->createValue($fieldValue, $context);
+        } else {
             $fieldType = $this->fieldTypeService->getFieldType($fieldTypeIdentifier);
             return $fieldType->fromHash($fieldValue);
             // was: error

--- a/Core/ComplexField/ComplexFieldManager.php
+++ b/Core/ComplexField/ComplexFieldManager.php
@@ -7,7 +7,7 @@ use eZ\Publish\API\Repository\FieldTypeService;
 
 class ComplexFieldManager
 {
-    /** @var ComplexFieldInterface[]  */
+    /** @var ComplexFieldInterface[][]  */
     protected $fieldTypeMap;
     protected $fieldTypeService;
 

--- a/Core/ComplexField/EzAuthor.php
+++ b/Core/ComplexField/EzAuthor.php
@@ -24,12 +24,12 @@ class EzAuthor extends AbstractComplexField implements ComplexFieldInterface
 
         /// @deprecated
         if (isset($fieldValueArray['authors'])) {
-            foreach($fieldValueArray['authors'] as $author) {
+            foreach ($fieldValueArray['authors'] as $author) {
                 $authors[] = new Author($author);
             }
         } else if (is_array($fieldValueArray)) {
             /// same as what fromHash() does, really
-            foreach($fieldValueArray as $author) {
+            foreach ($fieldValueArray as $author) {
                 $authors[] = new Author($author);
             }
         }

--- a/Core/ComplexField/EzBinaryFile.php
+++ b/Core/ComplexField/EzBinaryFile.php
@@ -32,7 +32,7 @@ class EzBinaryFile extends AbstractComplexField implements ComplexFieldInterface
         }
 
         // default format: path is relative to the 'files' dir
-        $realFilePath = dirname($context['path']) .  '/files/' . $filePath;
+        $realFilePath = dirname($context['path']) . '/files/' . $filePath;
 
         // but in the past, when using a string, this worked as well as an absolute path, so we have to support it as well
         if (!is_file($realFilePath) && is_file($filePath)) {

--- a/Core/ComplexField/EzRelation.php
+++ b/Core/ComplexField/EzRelation.php
@@ -24,7 +24,7 @@ class EzRelation extends AbstractComplexField implements ComplexFieldInterface
      */
     public function createValue($fieldValue, array $context = array())
     {
-        if (count($fieldValue) == 1 && isset($fieldValue['destinationContentId'])) {
+        if (array_key_exists('destinationContentId', $fieldValue)) {
             // fromHash format
             $id = $fieldValue['destinationContentId'];
         } else {

--- a/Core/ComplexField/EzRelationList.php
+++ b/Core/ComplexField/EzRelationList.php
@@ -22,14 +22,14 @@ class EzRelationList extends AbstractComplexField implements ComplexFieldInterfa
      */
     public function createValue($fieldValueArray, array $context = array())
     {
-        if (count($fieldValueArray) == 1 && isset($fieldValueArray['destinationContentIds'])) {
+        if (array_key_exists('destinationContentIds', $fieldValueArray)) {
             // fromHash format
             $ids = $fieldValueArray['destinationContentIds'];
-        } else if ($fieldValueArray === null) {
-            $ids = array();
-        } else {
+        } elseif (is_array($fieldValueArray)) {
             // simplified format
             $ids = $fieldValueArray;
+        } else {
+            $ids = array();
         }
 
         foreach ($ids as $key => $id) {

--- a/Core/ComplexField/EzRichText.php
+++ b/Core/ComplexField/EzRichText.php
@@ -36,7 +36,7 @@ class EzRichText extends AbstractComplexField implements ComplexFieldInterface
         // we need to alter the regexp we get from the resolver, as it will be used to match parts of text, not the whole string
         $regexp = substr($this->resolver->getRegexp(), 1, -1);
         // NB: here we assume that all regexp resolvers give us a regexp with a very specific format...
-        $regexp = '/\['.preg_replace(array('/^\^/'), array('', ''), $regexp) . '[^]]+\]/';
+        $regexp = '/\[' . preg_replace(array('/^\^/'), array('', ''), $regexp) . '[^]]+\]/';
 
         $count = preg_match_all($regexp, $xmlText, $matches);
         // $matches[0][] will have the matched full string eg.: [reference:example_reference]

--- a/Core/ComplexField/EzRichText.php
+++ b/Core/ComplexField/EzRichText.php
@@ -25,10 +25,13 @@ class EzRichText extends AbstractComplexField implements ComplexFieldInterface
      */
     public function createValue($fieldValue, array $context = array())
     {
-        if (is_string($fieldValue)) {
-            $xmlText = $fieldValue;
-        } else {
+        if (array_key_exists('content', $fieldValue)) {
             $xmlText = $fieldValue['content'];
+        } elseif (array_key_exists('xml', $fieldValue)) {
+            // fromHash format
+            $xmlText = $fieldValue['xml'];
+        } else {
+            $xmlText = $fieldValue;
         }
 
         // Check if there are any references in the xml text and replace them.

--- a/Core/ComplexField/EzTags.php
+++ b/Core/ComplexField/EzTags.php
@@ -4,6 +4,7 @@ namespace Kaliop\eZMigrationBundle\Core\ComplexField;
 
 use Kaliop\eZMigrationBundle\API\ComplexFieldInterface;
 use Kaliop\eZMigrationBundle\Core\Matcher\TagMatcher;
+use Netgen\TagsBundle\Core\FieldType\Tags\Value as TagsValue;
 
 class EzTags extends AbstractComplexField implements ComplexFieldInterface
 {
@@ -19,13 +20,13 @@ class EzTags extends AbstractComplexField implements ComplexFieldInterface
      *
      * @param array $fieldValue
      * @param array $context The context for execution of the current migrations. Contains f.e. the path to the migration
-     * @return \Netgen\TagsBundle\Core\FieldType\Tags\Value
+     * @return TagsValue
      * @throws \Exception
      */
     public function createValue($fieldValue, array $context = array())
     {
         $tags = array();
-        foreach($fieldValue as $def)
+        foreach ($fieldValue as $def)
         {
             if (!is_array($def) || count($def) != 1) {
                 throw new \Exception('Definition of EzTags field is incorrect: each element of the tags array must be an array with one element');
@@ -36,11 +37,11 @@ class EzTags extends AbstractComplexField implements ComplexFieldInterface
 
             $identifier = $this->referenceResolver->resolveReference($identifier);
 
-            foreach($this->tagMatcher->match(array($type => $identifier)) as $id => $tag) {
+            foreach ($this->tagMatcher->match(array($type => $identifier)) as $id => $tag) {
                 $tags[$id] = $tag;
             }
         }
 
-        return new \Netgen\TagsBundle\Core\FieldType\Tags\Value(array_values($tags));
+        return new TagsValue(array_values($tags));
     }
 }

--- a/Core/ComplexField/EzXmlText.php
+++ b/Core/ComplexField/EzXmlText.php
@@ -25,10 +25,13 @@ class EzXmlText extends AbstractComplexField implements ComplexFieldInterface
      */
     public function createValue($fieldValue, array $context = array())
     {
-        if (is_string($fieldValue)) {
-            $xmlText = $fieldValue;
-        } else {
+        if (array_key_exists('content', $fieldValue)) {
             $xmlText = $fieldValue['content'];
+        } elseif (array_key_exists('xml', $fieldValue)) {
+            // fromHash format
+            $xmlText = $fieldValue['xml'];
+        } else {
+            $xmlText = $fieldValue;
         }
 
         // Check if there are any references in the xml text and replace them.

--- a/Core/ComplexField/EzXmlText.php
+++ b/Core/ComplexField/EzXmlText.php
@@ -36,7 +36,7 @@ class EzXmlText extends AbstractComplexField implements ComplexFieldInterface
         // we need to alter the regexp we get from the resolver, as it will be used to match parts of text, not the whole string
         $regexp = substr($this->resolver->getRegexp(), 1, -1);
         // NB: here we assume that all regexp resolvers give us a regexp with a very specific format...
-        $regexp = '/\['.preg_replace(array('/^\^/'), array('', ''), $regexp) . '[^]]+\]/';
+        $regexp = '/\[' . preg_replace(array('/^\^/'), array('', ''), $regexp) . '[^]]+\]/';
 
         $count = preg_match_all($regexp, $xmlText, $matches);
         // $matches[0][] will have the matched full string eg.: [reference:example_reference]

--- a/Core/DefinitionParser/AbstractDefinitionParser.php
+++ b/Core/DefinitionParser/AbstractDefinitionParser.php
@@ -27,7 +27,7 @@ class AbstractDefinitionParser
             $status = MigrationDefinition::STATUS_INVALID;
             $message = "$format migration file '{$definition->path}' must contain an array as top element";
         } else {
-            foreach($data as $i => $stepDef) {
+            foreach ($data as $i => $stepDef) {
                 if (!isset($stepDef['type']) || !is_string($stepDef['type'])) {
                     $status = MigrationDefinition::STATUS_INVALID;
                     $message = "$format migration file '{$definition->path}' misses or has a non-string 'type' element in step $i";
@@ -49,7 +49,7 @@ class AbstractDefinitionParser
         }
 
         $stepDefs = array();
-        foreach($data as $stepDef) {
+        foreach ($data as $stepDef) {
             $type = $stepDef['type'];
             unset($stepDef['type']);
             $stepDefs[] = new MigrationStep($type, $stepDef, array('path' => $definition->path));

--- a/Core/DefinitionParser/JsonDefinitionParser.php
+++ b/Core/DefinitionParser/JsonDefinitionParser.php
@@ -4,8 +4,6 @@ namespace Kaliop\eZMigrationBundle\Core\DefinitionParser;
 
 use Kaliop\eZMigrationBundle\API\DefinitionParserInterface;
 use Kaliop\eZMigrationBundle\API\Value\MigrationDefinition;
-use Kaliop\eZMigrationBundle\API\Value\MigrationStep;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Handles Json migration definitions.
@@ -34,7 +32,7 @@ class JsonDefinitionParser extends AbstractDefinitionParser implements Definitio
     {
         try {
             $data = json_decode($definition->rawDefinition, true);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return new MigrationDefinition(
                 $definition->name,
                 $definition->path,

--- a/Core/DefinitionParser/PHPDefinitionParser.php
+++ b/Core/DefinitionParser/PHPDefinitionParser.php
@@ -90,6 +90,10 @@ class PHPDefinitionParser implements DefinitionParserInterface
         );
     }
 
+    /**
+     * @param string $fileName
+     * @return string|null
+     */
     protected function getClassNameFromFile($fileName)
     {
         $parts = explode('_', pathinfo($fileName, PATHINFO_FILENAME), 2);

--- a/Core/DefinitionParser/YamlDefinitionParser.php
+++ b/Core/DefinitionParser/YamlDefinitionParser.php
@@ -4,7 +4,6 @@ namespace Kaliop\eZMigrationBundle\Core\DefinitionParser;
 
 use Kaliop\eZMigrationBundle\API\DefinitionParserInterface;
 use Kaliop\eZMigrationBundle\API\Value\MigrationDefinition;
-use Kaliop\eZMigrationBundle\API\Value\MigrationStep;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -34,7 +33,7 @@ class YamlDefinitionParser extends AbstractDefinitionParser implements Definitio
     {
         try {
             $data = Yaml::parse($definition->rawDefinition);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return new MigrationDefinition(
                 $definition->name,
                 $definition->path,

--- a/Core/EventListener/TracingStepExecutedListener.php
+++ b/Core/EventListener/TracingStepExecutedListener.php
@@ -38,7 +38,7 @@ class TracingStepExecutedListener
         $dsl = $event->getStep()->dsl;
         $action = isset($dsl['mode']) ? ($dsl['mode'] . 'd') : 'acted upon';
 
-        switch($type) {
+        switch ($type) {
             case 'content':
             case 'content_type':
             case 'language':
@@ -49,7 +49,7 @@ class TracingStepExecutedListener
             case 'tag':
             case 'user':
             case 'user_group':
-                $out = $type  . ' '. $this->getObjectIdentifierAsString($obj). ' has been ' . $action;
+                $out = $type . ' ' . $this->getObjectIdentifierAsString($obj) . ' has been ' . $action;
                 break;
             case 'sql':
                 $out = 'sql has been executed';
@@ -75,31 +75,38 @@ class TracingStepExecutedListener
     {
         if ($objOrCollection instanceof AbstractCollection || is_array($objOrCollection)) {
             $out = array();
-            foreach($objOrCollection as $obj) {
+            foreach ($objOrCollection as $obj) {
                 $out[] = $this->getObjectIdentifierAsString($obj);
             }
-            return implode(", ", $out) ;
+            return implode(", ", $out);
         }
 
-        switch(gettype($objOrCollection)) {
+        switch (gettype($objOrCollection)) {
 
             case 'object':
                 if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Content ||
-                    $objOrCollection instanceof \eZ\Publish\API\Repository\Values\User\UserGroup)
-                        return "'" . $objOrCollection->contentInfo->name . "'";
+                    $objOrCollection instanceof \eZ\Publish\API\Repository\Values\User\UserGroup
+                ) {
+                    return "'" . $objOrCollection->contentInfo->name . "'";
+                }
                 if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\ContentType\ContentType ||
                     $objOrCollection instanceof \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup ||
                     $objOrCollection instanceof \eZ\Publish\API\Repository\Values\ObjectState\ObjectState ||
                     $objOrCollection instanceof \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup ||
                     $objOrCollection instanceof \eZ\Publish\API\Repository\Values\User\Role ||
-                    $objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Section)
-                        return "'" . $objOrCollection->identifier . "'";
-                if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Location)
-                        return "'" . $objOrCollection->pathString . "'";
-                if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Language)
-                        return "'" . $objOrCollection->languageCode . "'";
-                if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\User\User)
-                        return "'" . $objOrCollection->login . "'";
+                    $objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Section
+                ) {
+                    return "'" . $objOrCollection->identifier . "'";
+                }
+                if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Location) {
+                    return "'" . $objOrCollection->pathString . "'";
+                }
+                if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\Content\Language) {
+                    return "'" . $objOrCollection->languageCode . "'";
+                }
+                if ($objOrCollection instanceof \eZ\Publish\API\Repository\Values\User\User) {
+                    return "'" . $objOrCollection->login . "'";
+                }
                 // unknown objects - we can't know what the desired identifier is...
                 return '';
 

--- a/Core/Executor/ContentManager.php
+++ b/Core/Executor/ContentManager.php
@@ -339,12 +339,13 @@ class ContentManager extends RepositoryExecutor
                 $fieldValue = $field;
             }
 
-            if (!isset($contentType->fieldDefinitionsByIdentifier[$fieldIdentifier])) {
-                throw new \Exception("Field '$fieldIdentifier' is not present in field type '{$contentType->identifier}'");
+            $fieldDefinition = $contentType->getFieldDefinition($fieldIdentifier);
+
+            if ($fieldDefinition === null) {
+                throw new \Exception("Field '$fieldIdentifier' is not present in content type '{$contentType->identifier}'");
             }
 
-            $fieldType = $contentType->fieldDefinitionsByIdentifier[$fieldIdentifier];
-            $fieldValue = $this->getFieldValue($fieldValue, $fieldType, $contentType->identifier, $this->context);
+            $fieldValue = $this->getFieldValue($fieldValue, $fieldDefinition, $contentType->identifier, $this->context);
 
             $createOrUpdateStruct->setField($fieldIdentifier, $fieldValue, $this->getLanguageCode());
 
@@ -363,7 +364,7 @@ class ContentManager extends RepositoryExecutor
 
     protected function setObjectStates(Content $content, array $stateKeys)
     {
-        foreach($stateKeys as $stateKey) {
+        foreach ($stateKeys as $stateKey) {
             $stateKey = $this->referenceResolver->resolveReference($stateKey);
             /** @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $state */
             $state = $this->objectStateMatcher->matchOneByKey($stateKey);
@@ -492,7 +493,7 @@ class ContentManager extends RepositoryExecutor
     protected function toDateTime($date)
     {
         if (is_int($date)) {
-            return new \DateTime("@".$date);
+            return new \DateTime("@" . $date);
         } else {
             return new \DateTime($date);
         }

--- a/Core/Executor/ContentManager.php
+++ b/Core/Executor/ContentManager.php
@@ -9,6 +9,8 @@ use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
 use Kaliop\eZMigrationBundle\API\Collection\ContentCollection;
+use Kaliop\eZMigrationBundle\API\MigrationGeneratorInterface;
+use Kaliop\eZMigrationBundle\Core\ComplexField\ComplexFieldManager;
 use Kaliop\eZMigrationBundle\Core\Matcher\ContentMatcher;
 use Kaliop\eZMigrationBundle\Core\Matcher\SectionMatcher;
 use Kaliop\eZMigrationBundle\Core\Matcher\UserMatcher;
@@ -21,7 +23,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
  *
  * @todo add support for updating of content metadata
  */
-class ContentManager extends RepositoryExecutor
+class ContentManager extends RepositoryExecutor implements MigrationGeneratorInterface
 {
     protected $supportedStepTypes = array('content');
 
@@ -32,9 +34,14 @@ class ContentManager extends RepositoryExecutor
     protected $complexFieldManager;
     protected $locationManager;
 
-    public function __construct(ContentMatcher $contentMatcher, SectionMatcher $sectionMatcher, UserMatcher $userMatcher,
-        ObjectStateMatcher $objectStateMatcher, $complexFieldManager, $locationManager)
-    {
+    public function __construct(
+        ContentMatcher $contentMatcher,
+        SectionMatcher $sectionMatcher,
+        UserMatcher $userMatcher,
+        ObjectStateMatcher $objectStateMatcher,
+        ComplexFieldManager $complexFieldManager,
+        LocationManager $locationManager
+    ) {
         $this->contentMatcher = $contentMatcher;
         $this->sectionMatcher = $sectionMatcher;
         $this->userMatcher = $userMatcher;
@@ -63,9 +70,6 @@ class ContentManager extends RepositoryExecutor
 
         if (isset($this->dsl['always_available'])) {
             $contentCreateStruct->alwaysAvailable = $this->dsl['always_available'];
-        } else {
-            // Can be removed when https://github.com/kaliop-uk/ezmigrationbundle/pull/88 is merged
-            $contentCreateStruct->alwaysAvailable = $contentType->defaultAlwaysAvailable;
         }
 
         if (isset($this->dsl['remote_id'])) {
@@ -215,10 +219,17 @@ class ContentManager extends RepositoryExecutor
             $contentService->updateContent($draft->versionInfo, $contentUpdateStruct);
             $content = $contentService->publishVersion($draft->versionInfo);
 
-            if (isset($this->dsl['new_remote_id']) || isset($this->dsl['new_remote_id']) ||
-                isset($this->dsl['modification_date']) || isset($this->dsl['publication_date'])) {
+            if (isset($this->dsl['always_available']) ||
+                isset($this->dsl['new_remote_id']) ||
+                isset($this->dsl['owner']) ||
+                isset($this->dsl['modification_date']) ||
+                isset($this->dsl['publication_date'])) {
 
                 $contentMetaDataUpdateStruct = $contentService->newContentMetadataUpdateStruct();
+
+                if (isset($this->dsl['always_available'])) {
+                    $contentMetaDataUpdateStruct->alwaysAvailable = $this->dsl['always_available'];
+                }
 
                 if (isset($this->dsl['new_remote_id'])) {
                     $contentMetaDataUpdateStruct->remoteId = $this->dsl['new_remote_id'];
@@ -497,5 +508,85 @@ class ContentManager extends RepositoryExecutor
         } else {
             return new \DateTime($date);
         }
+    }
+
+    /**
+     * @param string $matchType
+     * @param string $matchValue
+     * @param string $mode
+     * @throws \Exception
+     * @return array
+     */
+    public function generateMigration($matchType, $matchValue, $mode)
+    {
+        $this->loginUser(self::ADMIN_USER_ID);
+        $contentCollection = $this->contentMatcher->match(array($matchType => $matchValue));
+        $data = array();
+
+        /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
+        foreach ($contentCollection as $content) {
+            $location = $this->repository->getLocationService()->loadLocation($content->contentInfo->mainLocationId);
+            $contentType = $this->repository->getContentTypeService()->loadContentType(
+                $content->contentInfo->contentTypeId
+            );
+            $fieldTypeService = $this->repository->getFieldTypeService();
+
+            $attributes = array();
+            foreach ($content->getFieldsByLanguage($this->getLanguageCode()) as $field) {
+                $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
+                $fieldType = $fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier);
+                $attributes[$field->fieldDefIdentifier] = $fieldType->toHash($field->value);
+            }
+
+            $contentData = array(
+                'type' => 'content',
+                'mode' => $mode
+            );
+
+            switch ($mode) {
+                case 'create':
+                    // @todo Add sort_field and sort_order
+                    $contentData = array_merge(
+                        $contentData,
+                        array(
+                            'content_type' => $contentType->identifier,
+                            'parent_location' => $location->parentLocationId,
+                            'priority' => $location->priority,
+                            'is_hidden' => $location->invisible,
+                            'remote_id' => $content->contentInfo->remoteId,
+                            'location_remote_id' => $location->remoteId
+                        )
+                    );
+                    break;
+                case 'update':
+                    $contentData = array_merge(
+                        $contentData,
+                        array(
+                            'match' => array(
+                                'content_remote_id' => $content->contentInfo->remoteId
+                            )
+                        )
+                    );
+                    break;
+                default:
+                    throw new \Exception("Executor 'content' doesn't support mode '$mode'");
+            }
+
+            $contentData = array_merge(
+                $contentData,
+                array(
+                    'lang' => $this->getLanguageCode(),
+                    'section' => $content->contentInfo->sectionId,
+                    'owner' => $content->contentInfo->ownerId,
+                    'modification_date' => $content->contentInfo->modificationDate,
+                    'publication_date' => $content->contentInfo->publishedDate,
+                    'always_available' => $content->contentInfo->alwaysAvailable,
+                    'attributes' => $attributes
+                )
+            );
+            $data[] = $contentData;
+        }
+
+        return $data;
     }
 }

--- a/Core/Executor/ContentTypeManager.php
+++ b/Core/Executor/ContentTypeManager.php
@@ -36,7 +36,7 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
      */
     protected function create()
     {
-        foreach(array('identifier', 'content_type_group', 'name_pattern', 'name', 'attributes') as $key) {
+        foreach (array('identifier', 'content_type_group', 'name_pattern', 'name', 'attributes') as $key) {
             if (!isset($this->dsl[$key])) {
                 throw new \Exception("The '$key' key is missing in a content type creation definition");
             }
@@ -213,7 +213,7 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
 
     /**
      * @param string $action
-     * @return RoleCollection
+     * @return ContentTypeCollection
      * @throws \Exception
      */
     protected function matchContentTypes($action)
@@ -251,7 +251,7 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
      * @throws \InvalidArgumentException When trying to set
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType|ContentTypeCollection $contentType
-     * @return boolean
+     * @return false|null
      */
     protected function setReferences($contentType)
     {
@@ -430,11 +430,11 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
      *
      * @param ContentType $contentType
      * @param string $fieldIdentifier
-     * @return null|FieldDefinition
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
      */
     private function contentTypeHasFieldDefinition(ContentType $contentType, $fieldIdentifier)
     {
-        $existingFieldDefinitions = $contentType->fieldDefinitions;
+        $existingFieldDefinitions = $contentType->getFieldDefinitions();
 
         foreach ($existingFieldDefinitions as $existingFieldDefinition) {
             if ($fieldIdentifier == $existingFieldDefinition->identifier) {

--- a/Core/Executor/ContentTypeManager.php
+++ b/Core/Executor/ContentTypeManager.php
@@ -446,77 +446,84 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
     }
 
     /**
-     * @param string $identifier
+     * @param string $matchType
+     * @param string $matchValue
      * @param string $mode
      * @throws \Exception
      * @return array
      */
-    public function generateMigration($identifier, $mode)
+    public function generateMigration($matchType, $matchValue, $mode)
     {
         $this->loginUser(self::ADMIN_USER_ID);
-        $contentType = $this->repository->getContentTypeService()->loadContentTypeByIdentifier($identifier);
+        $contentTypeCollection = $this->contentTypeMatcher->match(array($matchType => $matchValue));
+        $data = array();
 
-        $attributes = array();
-        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
-            $attributes[] = array(
-                'identifier' => $fieldDefinition->identifier,
-                'type' => $fieldDefinition->fieldTypeIdentifier,
-                'name' => $fieldDefinition->getName($this->getLanguageCode()),
-                'description' => $fieldDefinition->getDescription($this->getLanguageCode()),
-                'required' => $fieldDefinition->isRequired,
-                'searchable' => $fieldDefinition->isSearchable,
-                'info-collector' => $fieldDefinition->isInfoCollector,
-                'disable-translation' => !$fieldDefinition->isTranslatable,
-                'category' => $fieldDefinition->fieldGroup,
-                'default-value' => $fieldDefinition->defaultValue,
-                'field-settings' => $fieldDefinition->fieldSettings,
-                'position' => $fieldDefinition->position
+        /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType */
+        foreach ($contentTypeCollection as $contentType) {
+            $attributes = array();
+            foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
+                $attributes[] = array(
+                    'identifier' => $fieldDefinition->identifier,
+                    'type' => $fieldDefinition->fieldTypeIdentifier,
+                    'name' => $fieldDefinition->getName($this->getLanguageCode()),
+                    'description' => $fieldDefinition->getDescription($this->getLanguageCode()),
+                    'required' => $fieldDefinition->isRequired,
+                    'searchable' => $fieldDefinition->isSearchable,
+                    'info-collector' => $fieldDefinition->isInfoCollector,
+                    'disable-translation' => !$fieldDefinition->isTranslatable,
+                    'category' => $fieldDefinition->fieldGroup,
+                    'default-value' => $fieldDefinition->defaultValue,
+                    'field-settings' => $fieldDefinition->fieldSettings,
+                    'position' => $fieldDefinition->position
+                );
+            }
+
+            $contentTypeData = array(
+                'type' => 'content_type',
+                'mode' => $mode
             );
-        }
 
-        $data = array(
-            'type' => 'content_type',
-            'mode' => $mode
-        );
-
-        switch ($mode) {
-            case 'create':
-                $contentTypeGroups = $contentType->getContentTypeGroups();
-                $data = array_merge(
-                    $data,
-                    array(
-                        'content_type_group' => reset($contentTypeGroups)->identifier,
-                        'identifier' => $identifier
-                    )
-                );
-                break;
-            case 'update':
-                $data = array_merge(
-                    $data,
-                    array(
-                        'match' => array(
-                            'identifier' => $identifier
+            switch ($mode) {
+                case 'create':
+                    $contentTypeGroups = $contentType->getContentTypeGroups();
+                    $contentTypeData = array_merge(
+                        $contentTypeData,
+                        array(
+                            'content_type_group' => reset($contentTypeGroups)->identifier,
+                            'identifier' => $contentType->identifier
                         )
-                    )
-                );
-                break;
-            default:
-                throw new \Exception("Executor 'content_type' doesn't support mode '$mode'");
+                    );
+                    break;
+                case 'update':
+                    $contentTypeData = array_merge(
+                        $contentTypeData,
+                        array(
+                            'match' => array(
+                                'identifier' => $contentType->identifier
+                            )
+                        )
+                    );
+                    break;
+                default:
+                    throw new \Exception("Executor 'content_type' doesn't support mode '$mode'");
+            }
+
+            $contentTypeData = array_merge(
+                $contentTypeData,
+                array(
+                    'name' => $contentType->getName($this->getLanguageCode()),
+                    'description' => $contentType->getDescription($this->getLanguageCode()),
+                    'name_pattern' => $contentType->nameSchema,
+                    'url_name_pattern' => $contentType->urlAliasSchema,
+                    'is_container' => $contentType->isContainer,
+                    'lang' => $this->getLanguageCode(),
+                    'attributes' => $attributes
+                )
+            );
+
+            $data[] = $contentTypeData;
         }
 
-        $data = array_merge(
-            $data,
-            array(
-                'name' => $contentType->getName($this->getLanguageCode()),
-                'description' => $contentType->getDescription($this->getLanguageCode()),
-                'name_pattern' => $contentType->nameSchema,
-                'url_name_pattern' => $contentType->urlAliasSchema,
-                'is_container' => $contentType->isContainer,
-                'lang' => $this->getLanguageCode(),
-                'attributes' => $attributes
-            )
-        );
-
-        return array($data);
+        return $data;
     }
 }

--- a/Core/Executor/LocationManager.php
+++ b/Core/Executor/LocationManager.php
@@ -187,7 +187,6 @@ class LocationManager extends RepositoryExecutor
         $locationCollection = $this->matchLocations('delete');
 
         foreach ($locationCollection as $location) {
-            //$location = $locationService->loadLocation($locationId);
             $locationService->deleteLocation($location);
         }
 
@@ -196,12 +195,12 @@ class LocationManager extends RepositoryExecutor
 
     /**
      * @param string $action
-     * @return ContentCollection
+     * @return LocationCollection
      * @throws \Exception
      */
     protected function matchLocations($action)
     {
-        if (!isset($this->dsl['location_id'])&& !isset($this->dsl['match'])) {
+        if (!isset($this->dsl['location_id']) && !isset($this->dsl['match'])) {
             throw new \Exception("The ID or a Match Condition is required to $action a location.");
         }
 
@@ -228,7 +227,7 @@ class LocationManager extends RepositoryExecutor
 
     /**
      * @param int|string|array $locationKey
-     * @return mixed
+     * @return Location
      */
     public function matchLocationByKey($locationKey)
     {

--- a/Core/Executor/ObjectStateGroupManager.php
+++ b/Core/Executor/ObjectStateGroupManager.php
@@ -32,7 +32,7 @@ class ObjectStateGroupManager extends RepositoryExecutor
      */
     protected function create()
     {
-        foreach(array('names', 'identifier') as $key) {
+        foreach (array('names', 'identifier') as $key) {
             if (!isset($this->dsl[$key])) {
                 throw new \Exception("The '$key' key is missing in a object state group creation definition");
             }
@@ -79,8 +79,6 @@ class ObjectStateGroupManager extends RepositoryExecutor
         }
 
         foreach ($groupsCollection as $objectStateGroup) {
-            //$objectStateGroup = $objectStateService->loadObjectStateGroup($this->dsl['id']);
-
             $objectStateGroupUpdateStruct = $objectStateService->newObjectStateGroupUpdateStruct();
 
             if (isset($this->dsl['identifier'])) {
@@ -149,6 +147,7 @@ class ObjectStateGroupManager extends RepositoryExecutor
 
     /**
      * {@inheritdoc}
+     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
      */
     protected function setReferences($objectStateGroup)
     {

--- a/Core/Executor/ObjectStateManager.php
+++ b/Core/Executor/ObjectStateManager.php
@@ -5,7 +5,6 @@ namespace Kaliop\eZMigrationBundle\Core\Executor;
 use Kaliop\eZMigrationBundle\Core\Matcher\ObjectStateGroupMatcher;
 use Kaliop\eZMigrationBundle\Core\Matcher\ObjectStateMatcher;
 use Kaliop\eZMigrationBundle\API\Collection\ObjectStateCollection;
-use Kaliop\eZMigrationBundle\API\KeyMatcherInterface;
 
 class ObjectStateManager extends RepositoryExecutor
 {
@@ -41,7 +40,7 @@ class ObjectStateManager extends RepositoryExecutor
      */
     protected function create()
     {
-        foreach(array('object_state_group', 'names', 'identifier') as $key) {
+        foreach (array('object_state_group', 'names', 'identifier') as $key) {
             if (!isset($this->dsl[$key])) {
                 throw new \Exception("The '$key' key is missing in a object state creation definition");
             }
@@ -164,6 +163,7 @@ class ObjectStateManager extends RepositoryExecutor
 
     /**
      * {@inheritdoc}
+     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      */
     protected function setReferences($objectState)
     {

--- a/Core/Executor/RoleManager.php
+++ b/Core/Executor/RoleManager.php
@@ -44,7 +44,7 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
         }
 
         if (isset($this->dsl['policies'])) {
-            foreach($this->dsl['policies'] as $key => $ymlPolicy) {
+            foreach ($this->dsl['policies'] as $key => $ymlPolicy) {
                 $this->addPolicy($role, $roleService, $ymlPolicy);
             }
         }
@@ -92,11 +92,11 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
                 // Removing all policies so we can add them back.
                 // TODO: Check and update policies instead of remove and add.
                 $policies = $role->getPolicies();
-                foreach($policies as $policy) {
+                foreach ($policies as $policy) {
                     $roleService->deletePolicy($policy);
                 }
 
-                foreach($ymlPolicies as $ymlPolicy) {
+                foreach ($ymlPolicies as $ymlPolicy) {
                     $this->addPolicy($role, $roleService, $ymlPolicy);
                 }
             }
@@ -223,7 +223,7 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
 
         $limitationValue = is_array($limitation['values']) ? $limitation['values'] : array($limitation['values']);
 
-        foreach($limitationValue as $id => $value) {
+        foreach ($limitationValue as $id => $value) {
             $limitationValue[$id] = $this->referenceResolver->resolveReference($value);
         }
         $limitationValue = $this->limitationConverter->resolveLimitationValue($limitation['identifier'], $limitationValue);

--- a/Core/Executor/TagManager.php
+++ b/Core/Executor/TagManager.php
@@ -2,9 +2,9 @@
 
 namespace Kaliop\eZMigrationBundle\Core\Executor;
 
-use Kaliop\eZMigrationBundle\Core\ReferenceResolver\ReferenceHandler;
 use Kaliop\eZMigrationBundle\Core\Matcher\TagMatcher;
 use Kaliop\eZMigrationBundle\API\Collection\TagCollection;
+use Netgen\TagsBundle\API\Repository\Values\Tags\TagCreateStruct;
 
 class TagManager extends RepositoryExecutor
 {
@@ -21,7 +21,7 @@ class TagManager extends RepositoryExecutor
      * @param TagMatcher $tagMatcher
      * @param \Netgen\TagsBundle\Core\SignalSlot\TagsService $tagService
      */
-    public function __construct(TagMatcher $tagMatcher, $tagService=null)
+    public function __construct(TagMatcher $tagMatcher, $tagService = null)
     {
         $this->tagMatcher = $tagMatcher;
         $this->tagService = $tagService;
@@ -58,7 +58,7 @@ class TagManager extends RepositoryExecutor
             'alwaysAvailable' => $alwaysAvail,
             'remoteId' => $remoteId
         );
-        $tagCreateStruct = new \Netgen\TagsBundle\API\Repository\Values\Tags\TagCreateStruct($tagCreateArray);
+        $tagCreateStruct = new TagCreateStruct($tagCreateArray);
 
         foreach ($this->dsl['keywords'] as $langCode => $keyword)
         {
@@ -131,7 +131,7 @@ class TagManager extends RepositoryExecutor
 
     /**
      * @param $object
-     * @return mixed
+     * @return false|null
      */
     protected function setReferences($object)
     {

--- a/Core/Executor/UserGroupManager.php
+++ b/Core/Executor/UserGroupManager.php
@@ -49,7 +49,7 @@ class UserGroupManager extends RepositoryExecutor
             $roleService = $this->repository->getRoleService();
             // we support both Ids and Identifiers
             foreach ($this->dsl['roles'] as $roleId) {
-                if($this->referenceResolver->isReference($roleId)) {
+                if ($this->referenceResolver->isReference($roleId)) {
                     $roleId = $this->referenceResolver->resolveReference($roleId);
                 }
                 $role = $this->roleMatcher->matchOneByKey($roleId);
@@ -78,7 +78,7 @@ class UserGroupManager extends RepositoryExecutor
         $userService = $this->repository->getUserService();
         $contentService = $this->repository->getContentService();
 
-        foreach($userGroupCollection as $key => $userGroup) {
+        foreach ($userGroupCollection as $key => $userGroup) {
 
             /** @var $updateStruct \eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct */
             $updateStruct = $userService->newUserGroupUpdateStruct();
@@ -127,7 +127,7 @@ class UserGroupManager extends RepositoryExecutor
 
         $userService = $this->repository->getUserService();
 
-        foreach($userGroupCollection as $userGroup) {
+        foreach ($userGroupCollection as $userGroup) {
             $userService->deleteUserGroup($userGroup);
         }
 
@@ -136,7 +136,7 @@ class UserGroupManager extends RepositoryExecutor
 
     /**
      * @param string $action
-     * @return RoleCollection
+     * @return UserGroupCollection
      * @throws \Exception
      */
     protected function matchUserGroups($action)

--- a/Core/Executor/UserManager.php
+++ b/Core/Executor/UserManager.php
@@ -88,7 +88,7 @@ class UserManager extends RepositoryExecutor
 
         $userService = $this->repository->getUserService();
 
-        foreach($userCollection as $key => $user) {
+        foreach ($userCollection as $key => $user) {
 
             $userUpdateStruct = $userService->newUserUpdateStruct();
 
@@ -152,7 +152,7 @@ class UserManager extends RepositoryExecutor
 
         $userService = $this->repository->getUserService();
 
-        foreach($userCollection as $user) {
+        foreach ($userCollection as $user) {
             $userService->deleteUser($user);
         }
 
@@ -161,7 +161,7 @@ class UserManager extends RepositoryExecutor
 
     /**
      * @param string $action
-     * @return RoleCollection
+     * @return UserCollection
      * @throws \Exception
      */
     protected function matchUsers($action)
@@ -174,7 +174,7 @@ class UserManager extends RepositoryExecutor
         if (!isset($this->dsl['match'])) {
             $conds = array();
             if (isset($this->dsl['id'])) {
-                 $conds['id'] = $this->dsl['id'];
+                $conds['id'] = $this->dsl['id'];
             }
             if (isset($this->dsl['user_id'])) {
                 $conds['id'] = $this->dsl['user_id'];

--- a/Core/Helper/LimitationConverter.php
+++ b/Core/Helper/LimitationConverter.php
@@ -53,7 +53,7 @@ class LimitationConverter
                 }
                 break;
             case 'SiteAccess':
-                foreach($values as $value) {
+                foreach ($values as $value) {
                     $name = "No/unknown SiteAccess Found";
                     if (array_key_exists($value, $this->siteAccessList)) {
                         $name = $this->siteAccessList[$value];
@@ -63,7 +63,7 @@ class LimitationConverter
                 break;
             case 'ParentClass':
             case 'Class':
-                foreach($values as $value) {
+                foreach ($values as $value) {
                     $contentType = $this->contentTypeMatcher->matchOneByKey($value);
                     $retValues[] = $contentType->identifier;
                 }
@@ -106,7 +106,7 @@ class LimitationConverter
                 break;
             case 'SiteAccess':
                 $siteAccesses = array_flip($this->siteAccessList);
-                foreach($values as $value) {
+                foreach ($values as $value) {
                     if (!isset($siteAccesses[$value])) {
                         throw new \Exception("SiteAccess '$value' is not configured");
                     }
@@ -115,7 +115,7 @@ class LimitationConverter
                 break;
             case 'ParentClass':
             case 'Class':
-                foreach($values as $value) {
+                foreach ($values as $value) {
                     $contentType = $this->contentTypeMatcher->matchOneByKey($value);
                     $retValues[] = $contentType->id;
                 }

--- a/Core/Loader/Filesystem.php
+++ b/Core/Loader/Filesystem.php
@@ -57,7 +57,7 @@ class Filesystem implements LoaderInterface
         if (empty($paths)) {
             $paths = array();
             /** @var $bundle \Symfony\Component\HttpKernel\Bundle\BundleInterface */
-            foreach($this->kernel->getBundles() as $bundle)
+            foreach ($this->kernel->getBundles() as $bundle)
             {
                 $path = $bundle->getPath() . "/" . $this->versionDirectory;
                 if (is_dir($path)) {
@@ -67,7 +67,7 @@ class Filesystem implements LoaderInterface
         }
 
         $definitions = array();
-        foreach($paths as $path) {
+        foreach ($paths as $path) {
             if (is_file($path)) {
                 $definitions[basename($path)] = $returnFilename ? $path : new MigrationDefinition(
                     basename($path),
@@ -85,8 +85,7 @@ class Filesystem implements LoaderInterface
                             );
                     }
                 }
-            }
-            else {
+            } else {
                 throw new \Exception("Path '$path' is neither a file nor directory");
             }
         }

--- a/Core/Matcher/ObjectStateMatcher.php
+++ b/Core/Matcher/ObjectStateMatcher.php
@@ -115,9 +115,9 @@ class ObjectStateMatcher extends RepositoryMatcher implements KeyMatcherInterfac
         $groups = $this->repository->getObjectStateService()->loadObjectStateGroups();
         foreach ($groups as $group) {
             $groupStates = $this->repository->getObjectStateService()->loadObjectStates($group);
-            foreach($groupStates as $groupState) {
+            foreach ($groupStates as $groupState) {
                 // we always add the states using 'group/state' identifiers
-                $statesList[$group->identifier.'/'.$groupState->identifier] = $groupState;
+                $statesList[$group->identifier . '/' . $groupState->identifier] = $groupState;
                 // we only add the state using plain identifier if it is unique
                 if (isset($statesList[$groupState->identifier])) {
                     unset($statesList[$groupState->identifier]);

--- a/Core/Matcher/TagMatcher.php
+++ b/Core/Matcher/TagMatcher.php
@@ -30,7 +30,7 @@ class TagMatcher extends AbstractMatcher implements KeyMatcherInterface
      * @param $translationHelper
      * @param \Netgen\TagsBundle\API\Repository\TagsService $tagService
      */
-    public function __construct($translationHelper, $tagService=null)
+    public function __construct($translationHelper, $tagService = null)
     {
         $this->translationHelper = $translationHelper;
         $this->tagService = $tagService;
@@ -86,7 +86,7 @@ class TagMatcher extends AbstractMatcher implements KeyMatcherInterface
             return array(self::MATCH_TAG_ID => $key);
         }
 
-        throw new \Exception("Tag matcher can not uniquely identify the type of key used to match: ".key);
+        throw new \Exception("Tag matcher can not uniquely identify the type of key used to match: " . $key);
     }
 
     /**
@@ -135,7 +135,7 @@ class TagMatcher extends AbstractMatcher implements KeyMatcherInterface
 
         foreach ($tagKeywords as $tagKeyword) {
             // return unique contents
-            foreach($this->tagService->loadTagsByKeyword($tagKeyword, $availableLanguages[0]) as $tag) {
+            foreach ($this->tagService->loadTagsByKeyword($tagKeyword, $availableLanguages[0]) as $tag) {
                 $tags[$tag->id] = $tag;
             }
         }

--- a/Core/MigrationService.php
+++ b/Core/MigrationService.php
@@ -60,7 +60,7 @@ class MigrationService
 
     public function addExecutor(ExecutorInterface $executor)
     {
-        foreach($executor->supportedTypes() as $type) {
+        foreach ($executor->supportedTypes() as $type) {
             $this->executors[$type] = $executor;
         }
     }
@@ -89,8 +89,8 @@ class MigrationService
     {
         // we try to be flexible in file types we support, and the same time avoid loading all files in a directory
         $handledDefinitions = array();
-        foreach($this->loader->listAvailableDefinitions($paths) as $migrationName => $definitionPath) {
-            foreach($this->DefinitionParsers as $definitionParser) {
+        foreach ($this->loader->listAvailableDefinitions($paths) as $migrationName => $definitionPath) {
+            foreach ($this->DefinitionParsers as $definitionParser) {
                 if ($definitionParser->supports($migrationName)) {
                     $handledDefinitions[] = $definitionPath;
                 }
@@ -170,13 +170,13 @@ class MigrationService
      */
     public function parseMigrationDefinition(MigrationDefinition $migrationDefinition)
     {
-        foreach($this->DefinitionParsers as $definitionParser) {
+        foreach ($this->DefinitionParsers as $definitionParser) {
             if ($definitionParser->supports($migrationDefinition->name)) {
                 // parse the source file
                 $migrationDefinition = $definitionParser->parseMigrationDefinition($migrationDefinition);
 
                 // and make sure we know how to handle all steps
-                foreach($migrationDefinition->steps as $step) {
+                foreach ($migrationDefinition->steps as $step) {
                     if (!isset($this->executors[$step->type])) {
                         return new MigrationDefinition(
                             $migrationDefinition->name,
@@ -236,7 +236,7 @@ class MigrationService
 
             $i = 1;
 
-            foreach($migrationDefinition->steps as $step) {
+            foreach ($migrationDefinition->steps as $step) {
                 // we validated the fact that we have a good executor at parsing time
                 $executor = $this->executors[$step->type];
 
@@ -269,7 +269,7 @@ class MigrationService
                 $this->loginUser($previousUserId);
             }
 
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
 
             $errorMessage = $this->getFullExceptionMessage($e) . ' in file ' . $e->getFile() . ' line ' . $e->getLine();
             $finalStatus = Migration::STATUS_FAILED;
@@ -284,7 +284,7 @@ class MigrationService
                     // there is no need to become admin here, at least in theory
                     $this->repository->rollBack();
 
-                } catch(\Exception $e2) {
+                } catch (\Exception $e2) {
                     // This check is not rock-solid, but at the moment is all we can do to tell apart 2 cases of
                     // exceptions originating above: the case where the commit was successful but a commit-queue event
                     // failed, from the case where something failed beforehand
@@ -339,6 +339,7 @@ class MigrationService
                     return $message;
                 }
             } else if (is_a($e, '\eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException')) {
+                $errorsArray = array();
                 foreach ($e->getFieldErrors() as $limitationError) {
                     // we get the 1st language
                     $errorsArray[] = reset($limitationError);

--- a/Core/ReferenceResolver/ChainPrefixResolver.php
+++ b/Core/ReferenceResolver/ChainPrefixResolver.php
@@ -8,8 +8,8 @@ class ChainPrefixResolver extends ChainResolver implements PrefixBasedResolverIn
 {
     public function addResolver(ReferenceResolverInterface $resolver)
     {
-        if (! $resolver instanceof PrefixBasedResolverInterface) {
-            throw new \Exception("Can not add resolver of class " . get_class($resolver) .  " to a chain prefix resolver");
+        if (!$resolver instanceof PrefixBasedResolverInterface) {
+            throw new \Exception("Can not add resolver of class " . get_class($resolver) . " to a chain prefix resolver");
         }
 
         parent::addResolver($resolver);
@@ -22,7 +22,7 @@ class ChainPrefixResolver extends ChainResolver implements PrefixBasedResolverIn
     public function getRegexp()
     {
         $regexps = array();
-        foreach($this->resolvers as $resolver) {
+        foreach ($this->resolvers as $resolver) {
             $regexp = preg_replace('/^\^/', '', substr($resolver->getRegexp(), 1, -1));
             if ($regexp !== '') {
                 $regexps[] = $regexp;

--- a/Core/ReferenceResolver/ChainRegexpResolver.php
+++ b/Core/ReferenceResolver/ChainRegexpResolver.php
@@ -8,8 +8,8 @@ class ChainRegexpResolver extends ChainResolver implements RegexpBasedResolverIn
 {
     public function addResolver(ReferenceResolverInterface $resolver)
     {
-        if (! $resolver instanceof RegexpBasedResolverInterface) {
-            throw new \Exception("Can not add resolver of class " . get_class($resolver) .  " to a chain regexp resolver");
+        if (!$resolver instanceof RegexpBasedResolverInterface) {
+            throw new \Exception("Can not add resolver of class " . get_class($resolver) . " to a chain regexp resolver");
         }
 
         parent::addResolver($resolver);
@@ -22,7 +22,7 @@ class ChainRegexpResolver extends ChainResolver implements RegexpBasedResolverIn
     public function getRegexp()
     {
         $regexps = array();
-        foreach($this->resolvers as $resolver) {
+        foreach ($this->resolvers as $resolver) {
             $regexp = substr($resolver->getRegexp(), 1, -1);
             if ($regexp !== '') {
                 $regexps[] = $regexp;

--- a/Core/ReferenceResolver/ContentResolver.php
+++ b/Core/ReferenceResolver/ContentResolver.php
@@ -35,7 +35,7 @@ class ContentResolver extends AbstractResolver
     public function getReferenceValue($stringIdentifier)
     {
         $ref = $this->getReferenceIdentifierByPrefix($stringIdentifier);
-        switch($ref['prefix']) {
+        switch ($ref['prefix']) {
             case 'content_remote_id:':
                 return $this->contentMatcher->matchOne(array(ContentMatcher::MATCH_CONTENT_REMOTE_ID => $ref['identifier']))->id;
         }

--- a/Core/ReferenceResolver/LocationResolver.php
+++ b/Core/ReferenceResolver/LocationResolver.php
@@ -36,7 +36,7 @@ class LocationResolver extends AbstractResolver
     public function getReferenceValue($stringIdentifier)
     {
         $ref = $this->getReferenceIdentifierByPrefix($stringIdentifier);
-        switch($ref['prefix']) {
+        switch ($ref['prefix']) {
             // deprecated tag: 'location:'
             case 'location:':
                 return $this->locationMatcher->MatchOne(array(LocationMatcher::MATCH_LOCATION_REMOTE_ID => $ref['identifier']))->id;

--- a/Core/ReferenceResolver/PrefixBasedResolver.php
+++ b/Core/ReferenceResolver/PrefixBasedResolver.php
@@ -18,7 +18,7 @@ abstract class PrefixBasedResolver implements PrefixBasedResolverInterface
     public function __construct()
     {
         $quotedPrefixes = [];
-        foreach($this->referencePrefixes as $prefix) {
+        foreach ($this->referencePrefixes as $prefix) {
             $quotedPrefixes[] = preg_quote($prefix, '/');
         }
         $this->prefixMatchRegexp = '/^(' . implode('|', $quotedPrefixes) . ')/';
@@ -77,7 +77,7 @@ abstract class PrefixBasedResolver implements PrefixBasedResolverInterface
      */
     protected function getReferenceIdentifierByPrefix($stringIdentifier)
     {
-        foreach($this->referencePrefixes as $prefix) {
+        foreach ($this->referencePrefixes as $prefix) {
             $regexp = '/^' . preg_quote($prefix, '/') . '/';
             if (preg_match($regexp, $stringIdentifier)) {
                 return array('prefix' => $prefix, 'identifier' => preg_replace($regexp, '', $stringIdentifier));

--- a/Core/StorageHandler/Database.php
+++ b/Core/StorageHandler/Database.php
@@ -98,7 +98,7 @@ class Database implements StorageHandlerInterface
     /**
      * Creates and stores a new migration (leaving it in TODO status)
      * @param MigrationDefinition $migrationDefinition
-     * @return mixed
+     * @return Migration
      * @throws \Exception If the migration exists already (we rely on the PK for that)
      */
     public function addMigration(MigrationDefinition $migrationDefinition)
@@ -116,7 +116,7 @@ class Database implements StorageHandlerInterface
         );
         try {
             $conn->insert($this->migrationsTableName, $this->migrationToArray($migration));
-        } catch(UniqueConstraintViolationException $e) {
+        } catch (UniqueConstraintViolationException $e) {
             throw new \Exception("Migration '{$migrationDefinition->name}' already exists");
         }
 
@@ -150,7 +150,7 @@ class Database implements StorageHandlerInterface
      * @param bool $force When true, the migration will be updated even if it was not in 'started' status
      * @throws \Exception If the migration was not started (unless $force=true)
      */
-    public function endMigration(Migration $migration, $force=false)
+    public function endMigration(Migration $migration, $force = false)
     {
         if ($migration->status == Migration::STATUS_STARTED) {
             throw new \Exception("Migration '{$migration->name}' can not be ended as its status is 'started'...");
@@ -227,6 +227,13 @@ class Database implements StorageHandlerInterface
         return $this->createMigration($migrationDefinition, Migration::STATUS_SKIPPED, 'skipped');
     }
 
+    /**
+     * @param MigrationDefinition $migrationDefinition
+     * @param int $status
+     * @param string $action
+     * @return Migration
+     * @throws \Exception
+     */
     protected function createMigration(MigrationDefinition $migrationDefinition, $status, $action)
     {
         $this->createMigrationsTableIfNeeded();
@@ -273,7 +280,7 @@ class Database implements StorageHandlerInterface
                 $migrationDefinition->name,
                 md5($migrationDefinition->rawDefinition),
                 $migrationDefinition->path,
-                ($status == Migration::STATUS_SKIPPED ? null: time()),
+                ($status == Migration::STATUS_SKIPPED ? null : time()),
                 $status
             );
             $conn->update(
@@ -297,7 +304,7 @@ class Database implements StorageHandlerInterface
                 $migrationDefinition->name,
                 md5($migrationDefinition->rawDefinition),
                 $migrationDefinition->path,
-                ($status == Migration::STATUS_SKIPPED ? null: time()),
+                ($status == Migration::STATUS_SKIPPED ? null : time()),
                 $status
             );
             $conn->insert($this->migrationsTableName, $this->migrationToArray($migration));
@@ -362,7 +369,7 @@ class Database implements StorageHandlerInterface
         // and 767 bytes can be either 255 chars or 191 chars depending on charset utf8 or utf8mb4...
         //$t->addIndex(array('path'));
 
-        foreach($schema->toSql($dbPlatform) as $sql) {
+        foreach ($schema->toSql($dbPlatform) as $sql) {
             $this->dbHandler->exec($sql);
         }
     }
@@ -377,7 +384,7 @@ class Database implements StorageHandlerInterface
     {
         /** @var \Doctrine\DBAL\Schema\AbstractSchemaManager $sm */
         $sm = $this->dbHandler->getConnection()->getSchemaManager();
-        foreach($sm->listTables() as $table) {
+        foreach ($sm->listTables() as $table) {
             if ($table->getName() == $tableName) {
                 return true;
             }

--- a/DependencyInjection/EzMigrationExtension.php
+++ b/DependencyInjection/EzMigrationExtension.php
@@ -22,7 +22,7 @@ class EzMigrationExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }
 }

--- a/MigrationVersions/20100101000200_MigrateV1ToV2.php
+++ b/MigrationVersions/20100101000200_MigrateV1ToV2.php
@@ -1,7 +1,6 @@
 <?php
 
 use Kaliop\eZMigrationBundle\API\MigrationInterface;
-
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Kaliop\eZMigrationBundle\API\Value\Migration;
 use Kaliop\eZMigrationBundle\API\Value\MigrationDefinition;
@@ -36,7 +35,7 @@ class MigrateV1ToV2 implements MigrationInterface
         $this->dbHandler = $this->container->get('ezpublish.connection');
 
         $this->activeBundles = array();
-        foreach($this->container->get('kernel')->getBundles() as $bundle)
+        foreach ($this->container->get('kernel')->getBundles() as $bundle)
         {
             $this->activeBundles[$bundle->getName()] = $bundle->getPath();
         }
@@ -57,7 +56,7 @@ class MigrateV1ToV2 implements MigrationInterface
 
         // we need to decide of a random time to stamp existing migrations. We use 'now - 1 minute'...
         $executionDate = time() - 60;
-        foreach($toMigrate as $legacyMigration) {
+        foreach ($toMigrate as $legacyMigration) {
             $name = $legacyMigration['version'];
 
             $path = $this->getLegacyMigrationDefinition($legacyMigration['version'], $legacyMigration['bundle']);
@@ -104,7 +103,7 @@ class MigrateV1ToV2 implements MigrationInterface
     {
         /** @var \Doctrine\DBAL\Schema\AbstractSchemaManager $sm */
         $sm = $this->dbHandler->getConnection()->getSchemaManager();
-        foreach($sm->listTables() as $table) {
+        foreach ($sm->listTables() as $table) {
             if ($table->getName() == $tableName) {
                 return true;
             }
@@ -151,7 +150,7 @@ class MigrateV1ToV2 implements MigrationInterface
             return false;
         }
 
-        foreach($versionDefinitions as $key => $versionDefinition) {
+        foreach ($versionDefinitions as $key => $versionDefinition) {
             if (!in_array(pathinfo($versionDefinition, PATHINFO_EXTENSION), array('php', 'yml', 'sql'))) {
                 unset($versionDefinitions[$key]);
             }

--- a/Resources/doc/DSL/ManageContent.yml
+++ b/Resources/doc/DSL/ManageContent.yml
@@ -100,12 +100,13 @@
     modification_date: zzz # Optional, set content modification date (for formats, see: http://php.net/manual/en/datetime.formats.php)
     publication_date: zzz # Optional, set content publication date (for formats, see: http://php.net/manual/en/datetime.formats.php)
     new_remote_id: xxx # string Optional set a new RemoteId
+    always_available: true|false # Optional
     attributes: # the list of attribute identifier value pairs. For the format to use, see above
         attribute1: value1
         attribute2: value2
     # Optionally assign object states to the content
     object_states:
-        - xxx # int|string an object state id or didentifier. For the format to use, see above
+        - xxx # int|string an object state id or identifier. For the format to use, see above
     # The list in references tells the manager to store specific values for later use by other steps in the current migration.
     # NB: these are NEW VARIABLES THAT YOU ARE CREATING. They are not used in the current migration step!
     references: # Optional

--- a/Tests/phpunit/1_GenerateTest.php
+++ b/Tests/phpunit/1_GenerateTest.php
@@ -8,9 +8,22 @@ class GenerateTest extends CommandTest
 {
     /**
      * @dataProvider provideGenerateParameters
+     *
+     * @param string|null $name
+     * @param string|null $format
+     * @param string|null $type
+     * @param string|null $matchType
+     * @param string|null $matchValue
+     * @param string|null $mode
      */
-    public function testGenerateDSL($name, $format, $type, $identifier, $mode)
-    {
+    public function testGenerateDSL(
+        $name = null,
+        $format = null,
+        $type = null,
+        $matchType = null,
+        $matchValue = null,
+        $mode = null
+    ) {
         $parameters = array(
             'command' => 'kaliop:migration:generate',
             'bundle' => $this->targetBundle
@@ -28,8 +41,12 @@ class GenerateTest extends CommandTest
             $parameters['--type'] = $type;
         }
 
-        if ($identifier) {
-            $parameters['--identifier'] = $identifier;
+        if ($matchType) {
+            $parameters['--match_type'] = $matchType;
+        }
+
+        if ($matchValue) {
+            $parameters['--match_value'] = $matchValue;
         }
 
         if ($mode) {
@@ -46,17 +63,19 @@ class GenerateTest extends CommandTest
     public function provideGenerateParameters()
     {
         return array(
-            array(null, null, null, null, null),
-            array(null, 'sql', null, null, null),
-            array(null, 'php', null, null, null),
-            array('unit_test_generated', null, null, null, null),
-            array('unit_test_generated', 'sql', null, null, null),
-            array('unit_test_generated', 'php', null, null, null),
-            array('unit_test_generated_role', null, 'role', 'Anonymous', null),
-            array('unit_test_generated_role', null, 'role', 'Anonymous', 'create'),
-            array('unit_test_generated_role', null, 'role', 'Anonymous', 'update'),
-            array('unit_test_generated_content_type', 'yml', 'content_type', 'folder', null),
-            array('unit_test_generated_content_type', 'json', 'content_type', 'folder', 'update')
+            array(),
+            array(null, 'sql'),
+            array(null, 'php'),
+            array('unit_test_generated'),
+            array('unit_test_generated', 'sql'),
+            array('unit_test_generated', 'php'),
+            array('unit_test_generated_role', null, 'role', 'identifier', 'Anonymous'),
+            array('unit_test_generated_role', null, 'role', 'identifier', 'Anonymous', 'create'),
+            array('unit_test_generated_role', null, 'role', 'identifier', 'Anonymous', 'update'),
+            array('unit_test_generated_content_type', 'yml', 'content_type', 'identifier', 'folder'),
+            array('unit_test_generated_content_type', 'json', 'content_type', 'identifier', 'folder', 'update'),
+            array('unit_test_generated_content_type', 'yml', 'content', 'contenttype_identifier', 'folder'),
+            array('unit_test_generated_content_type', 'json', 'content', 'contenttype_identifier', 'folder', 'update')
         );
     }
 

--- a/Tests/phpunit/2_MigrateTest.php
+++ b/Tests/phpunit/2_MigrateTest.php
@@ -126,12 +126,12 @@ class MigrateTest extends CommandTest
     public function goodDSLProvider()
     {
         $dslDir = $this->dslDir.'/good';
-        if(!is_dir($dslDir)) {
+        if (!is_dir($dslDir)) {
             return array();
         }
 
         $out = array();
-        foreach(scandir($dslDir) as $fileName) {
+        foreach (scandir($dslDir) as $fileName) {
             $filePath = $dslDir . '/' . $fileName;
             if (is_file($filePath)) {
                 $out[] = array($filePath);
@@ -143,12 +143,12 @@ class MigrateTest extends CommandTest
     public function invalidDSLProvider()
     {
         $dslDir = $this->dslDir.'/bad/parsing';
-        if(!is_dir($dslDir)) {
+        if (!is_dir($dslDir)) {
             return array();
         }
 
         $out = array();
-        foreach(scandir($dslDir) as $fileName) {
+        foreach (scandir($dslDir) as $fileName) {
             $filePath = $dslDir . '/' . $fileName;
             if (is_file($filePath)) {
                 $out[] = array($filePath);
@@ -160,12 +160,12 @@ class MigrateTest extends CommandTest
     public function badDSLProvider()
     {
         $dslDir = $this->dslDir.'/bad/execution';
-        if(!is_dir($dslDir)) {
+        if (!is_dir($dslDir)) {
             return array();
         }
 
         $out = array();
-        foreach(scandir($dslDir) as $fileName) {
+        foreach (scandir($dslDir) as $fileName) {
             $filePath = $dslDir . '/' . $fileName;
             if (is_file($filePath)) {
                 $out[] = array($filePath);

--- a/Tests/phpunit/3_TagsTest.php
+++ b/Tests/phpunit/3_TagsTest.php
@@ -58,12 +58,12 @@ class TagsTest extends CommandTest
     public function goodDSLProvider()
     {
         $dslDir = $this->dslDir.'/eztags';
-        if(!is_dir($dslDir)) {
+        if (!is_dir($dslDir)) {
             return array();
         }
 
         $out = array();
-        foreach(scandir($dslDir) as $fileName) {
+        foreach (scandir($dslDir) as $fileName) {
             $filePath = $dslDir . '/' . $fileName;
             if (is_file($filePath)) {
                 $out[] = array($filePath);

--- a/Tests/phpunit/CommandTest.php
+++ b/Tests/phpunit/CommandTest.php
@@ -62,7 +62,7 @@ abstract class CommandTest extends WebTestCase
 
     protected function tearDown()
     {
-        foreach($this->leftovers as $file) {
+        foreach ($this->leftovers as $file) {
             unlink($file);
         }
 
@@ -92,7 +92,7 @@ abstract class CommandTest extends WebTestCase
         }
         try {
             static::$kernel = static::createKernel($options);
-        } catch(\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             throw new \RuntimeException($e->getMessage() . " Did you forget to define the environment variable KERNEL_DIR?", $e->getCode(), $e->getPrevious());
         }
         static::$kernel->boot();


### PR DESCRIPTION
Requires: https://github.com/kaliop-uk/ezmigrationbundle/pull/92

I removed the identifier parameter of the generate command.
For this I added match_type and match_value parameters.
So its possible to generate migrations of multiple contents.

I added also a lang parameter :)

Examples

`php ezpublish/console kaliop:migration:generate --type=content --match_type=parent_location_id --match_value=42 --lang=ger-DE AppBundle`

`php ezpublish/console kaliop:migration:generate --type=content --match_type=contenttype_identifier --match_value=folder --lang=ger-DE AppBundle`

`php ezpublish/console kaliop:migration:generate --type=content --match_type=content_id --match_value=42 --lang=ger-DE AppBundle`