### PR TITLE
Fix: Generated migration with empty relation field caused error

### DIFF
--- a/Core/ComplexField/EzRelation.php
+++ b/Core/ComplexField/EzRelation.php
@@ -25,7 +25,7 @@ class EzRelation extends AbstractComplexField implements FieldValueImporterInter
      */
     public function hashToFieldValue($fieldValue, array $context = array())
     {
-        if (count($fieldValue) == 1 && isset($fieldValue['destinationContentId'])) {
+        if (is_array($fieldValue) && array_key_exists('destinationContentId', $fieldValue)) {
             // fromHash format
             $id = $fieldValue['destinationContentId'];
         } else {


### PR DESCRIPTION
The generate command generates following attribute if the relation is empty:

`
-
    attributes:
        relation:
            destinationContentId: null
`

Than the isset function returns false and the import runs into an exception.