### PR TITLE
Stacktraces are not available

### DIFF
--- a/Command/MigrateCommand.php
+++ b/Command/MigrateCommand.php
@@ -182,7 +182,7 @@ EOT
                         continue;
                     }
                     $output->writeln("\n<error>Migration aborted! Reason: " . $e->getMessage() . "</error>");
-                    return 1;
+                    return $e;
                 }
 
             } else {
@@ -199,7 +199,7 @@ EOT
                         continue;
                     }
                     $output->writeln("\n<error>Migration aborted! Reason: " . $e->getMessage() . "</error>");
-                    return 1;
+                    return $e;
                 }
 
             }

--- a/Core/MigrationService.php
+++ b/Core/MigrationService.php
@@ -341,7 +341,7 @@ class MigrationService
                 true
             );
 
-            throw new MigrationStepExecutionException($errorMessage, $i, $e);
+            throw $e;
         }
     }
 


### PR DESCRIPTION
Having no stacktraces is not practicle for us programmers. We shall pass them along for debugging reasons. What do you think?

Also I think it needs more clean up. But I do not know why there is some much funny code.
Here https://github.com/kaliop-uk/ezmigrationbundle/blob/master/Core/MigrationService.php#L35 (What is the purpose?) I mean we love to see the original errors.`

https://github.com/kaliop-uk/ezmigrationbundle/blob/master/Core/MigrationService.php#L300 Maybe something to output in a logger

Having this fixed is very important for us.