### PR TITLE
Fix default language for migrations

### DIFF
--- a/Core/MigrationService.php
+++ b/Core/MigrationService.php
@@ -255,6 +255,9 @@ class MigrationService
                 foreach ($migrationDefinition->steps as $step) {
                     // we validated the fact that we have a good executor at parsing time
                     $executor = $this->executors[$step->type];
+                    if ($executor instanceof LanguageAwareInterface) {
+                        $executor->setLanguageCode(null);
+                    }
 
                     $beforeStepExecutionEvent = new BeforeStepExecutionEvent($step, $executor);
                     $this->dispatcher->dispatch($this->eventPrefix . 'before_execution', $beforeStepExecutionEvent);

--- a/Tests/dsl/UnitTestOK018_defaultLanguage.yml
+++ b/Tests/dsl/UnitTestOK018_defaultLanguage.yml
@@ -1,0 +1,41 @@
+-
+    type: language
+    mode: create
+    lang: def-LA
+    name: Kaliop Migration Bundle Language 1
+-
+    type: content_type
+    mode: create
+    content_type_group: 1
+    identifier: kmb_test_18
+    name: Kaliop Migration Bundle Test Class 18
+    name_pattern: '<ezstring>'
+    attributes:
+        -
+            type: ezstring
+            name: ezstring
+            identifier: ezstring
+    references:
+        -
+            identifier: kmb_test_18
+            attribute: identifier
+-
+    type: content
+    mode: create
+    content_type: 'reference:kmb_test_18'
+    remote_id: kmb_test_18_content_1
+    parent_location: 2
+    lang: eng-GB
+    attributes:
+        -
+            ezstring: hello world 1
+-
+    type: content
+    mode: create
+    content_type: 'reference:kmb_test_18'
+    remote_id: kmb_test_18_content_2
+    parent_location: 2
+    # lang: should be the default language (def-LA and not eng-GB from the previous)
+    attributes:
+        -
+            ezstring: hello world 2


### PR DESCRIPTION
The `--default-language` option does not really work for `kaliop:migration:migrate` currently.

If you set the `lang` for a content, then the executor sets the current language to that lang and never resets it. So it will use this lang as default for all following contents, ignoring the default language.

I just put a languageCode reset into the loop. Reset the language for the current executor before every step, so the `execute` method will always check if it should use default lang or not.

I made a phpunit unit test for this and refactored the tests a bit to remove some code duplications.

In the test dsl file you can see I create 2 contents. The default language is "def-LA".
I create the first content with `eng-GB` and omit the lang for the second content, so I expect the default here, so `def-LA`.
Before the patch, the 2. content will be `eng-GB` too, because default lang is replaced in the executor when adding the first content, which is unexpected.