### PR TITLE
Use field settings that already have references resolved

### DIFF
--- a/Core/Executor/ContentTypeManager.php
+++ b/Core/Executor/ContentTypeManager.php
@@ -676,7 +676,7 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
 
         // then handle the conversion of the settings from Hash to Repo representation
         if ($this->fieldHandlerManager->managesFieldDefinition($fieldTypeIdentifier, $contentTypeIdentifier)) {
-            $ret = $this->fieldHandlerManager->hashToFieldSettings($fieldTypeIdentifier, $contentTypeIdentifier, $value);
+            $ret = $this->fieldHandlerManager->hashToFieldSettings($fieldTypeIdentifier, $contentTypeIdentifier, $ret);
         }
 
         return $ret;


### PR DESCRIPTION
I'm facing an issue whereby I can't use a reference for `field-settings`. It looks like the references are resolved first and then the unresolved settings get used in `hashToFieldSettings`

I'm unsure on how to add a test for this to the existing phpunit setup but if someone could help that would be much appreciated.
This is the migration script I'm using that causes the issue:

```
-
    mode: create
    type: content
    content_type: folder
    main_location: 43 #Media
    priority: 0
    attributes:
        - name: Videos
    references:
        -
            identifier: video_location_id_ref
            attribute: location_id
-
    type: content_type
    mode: update
    identifier: article
    attributes:
        -
            type: ezobjectrelation
            name: Video
            identifier: video
            field-settings:
                selectionRoot: "reference:video_location_id_ref"
```