### PR TITLE
Content Type Manager: update_if_exists option

### DIFF
--- a/Resources/doc/DSL/ContentTypes.yml
+++ b/Resources/doc/DSL/ContentTypes.yml
@@ -107,6 +107,7 @@
     url_name_pattern: pattern # Optional
     default_sort_field: x # Optional. See ManageLocation.yml for details
     default_sort_order: ASC|DESC # Optional
+    update_if_exists: true|false # Optional, update the content type if it exists
     # The list in references tells the manager to store specific values for later use by other steps in the current
     # migration.
     references: # Optional


### PR DESCRIPTION
Adds a update_if_exists option to the create mode.

It is helpful if you are not sure if the content type already exists. E. g. for the first migration.
It could be the install of the bundle or already a update.