### PR TITLE
Content Type Manager: Update removes Name/Description translations

### DIFF
--- a/Core/Executor/ContentTypeManager.php
+++ b/Core/Executor/ContentTypeManager.php
@@ -166,12 +166,14 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
 
             if (isset($step->dsl['name'])) {
                 $contentTypeUpdateStruct->names = array($this->getLanguageCode($step) => $step->dsl['name']);
+                $contentTypeUpdateStruct->names += $contentTypeDraft->getNames();
             }
 
             if (isset($step->dsl['description'])) {
                 $contentTypeUpdateStruct->descriptions = array(
                     $this->getLanguageCode($step) => $step->dsl['description'],
                 );
+                $contentTypeUpdateStruct->descriptions += $contentTypeDraft->getDescriptions();
             }
 
             if (isset($step->dsl['name_pattern'])) {
@@ -209,6 +211,12 @@ class ContentTypeManager extends RepositoryExecutor implements MigrationGenerato
                         $fieldDefinitionUpdateStruct = $this->updateFieldDefinition(
                             $contentTypeService, $attribute, $attribute['identifier'], $contentType->identifier, $this->getLanguageCode($step)
                         );
+                        if (is_array($fieldDefinitionUpdateStruct->names)) {
+                            $fieldDefinitionUpdateStruct->names += $existingFieldDefinition->getNames();
+                        }
+                        if (is_array($fieldDefinitionUpdateStruct->descriptions)) {
+                            $fieldDefinitionUpdateStruct->descriptions += $existingFieldDefinition->getDescriptions();
+                        }
                         $contentTypeService->updateFieldDefinition(
                             $contentTypeDraft,
                             $existingFieldDefinition,


### PR DESCRIPTION
If I translate the name/description fields with an update, the other translations will be removed.