### PR TITLE
Fix for references in Tags migration documentation

### DIFF
--- a/Resources/doc/DSL/Tags.yml
+++ b/Resources/doc/DSL/Tags.yml
@@ -8,10 +8,11 @@
     keywords:
         language_code: "Keyword" # ex : eng-GB: "Test keyword"
     references: # Optional
-        identifier: referenceId # A string used to identify the reference
-        attribute: attributeId # The attribute to get the value of for the reference
-                               # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
-                               # path, parent_tag_id, remote_id
+        -
+            identifier: referenceId # A string used to identify the reference
+            attribute: attributeId # The attribute to get the value of for the reference
+                                   # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
+                                   # path, parent_tag_id, remote_id
 
 -
     type: tag
@@ -23,9 +24,9 @@
         language_code: "Keyword" # ex : eng-GB: "Test keyword"
     match: # The tag(s) to update
         # Possible values for matching. only one of them is allowed at a time. All of them can be single or array
-        id: # the id(s) of the tag(s) we want to delete
-        remote_id: # the remote id(s) of the tag(s) we want to delete
-        keyword: # the keyword(s) of the tag(s) we want to delete
+        id: # the id(s) of the tag(s) we want to update
+        remote_id: # the remote id(s) of the tag(s) we want to update
+        keyword: # the keyword(s) of the tag(s) we want to update
         or: # match any of the conditions below. *NB:* less efficient that using the array notation for a single condition
             -
                 _condition_: value # where _condition_ can be any of ones specified above, including 'and' and 'or'
@@ -37,10 +38,11 @@
             -
                 _condition_: value # where _condition_ can be any of ones specified above, including 'and' and 'or'
     references: # Optional
-        identifier: referenceId # A string used to identify the reference
-        attribute: attributeId # The attribute to get the value of for the reference
-                               # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
-                               # path, parent_tag_id, remote_id
+        -
+            identifier: referenceId # A string used to identify the reference
+            attribute: attributeId # The attribute to get the value of for the reference
+                                   # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
+                                   # path, parent_tag_id, remote_id
 
 -
     type: tag
@@ -61,17 +63,19 @@
             -
                 _condition_: value # where _condition_ can be any of ones specified above, including 'and' and 'or'
     references: # Optional
-        identifier: referenceId # A string used to identify the reference
-        attribute: attributeId # The attribute to get the value of for the reference
-                               # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
-                               # path, parent_tag_id, remote_id
+        -
+            identifier: referenceId # A string used to identify the reference
+            attribute: attributeId # The attribute to get the value of for the reference
+                                   # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
+                                   # path, parent_tag_id, remote_id
 
 -
     type: tag
     mode: load
     match: # The tag(s) to load; See above the description in the tag/delete operation for valid values
     references: # Optional
-        identifier: referenceId # A string used to identify the reference
-        attribute: attributeId # The attribute to get the value of for the reference
-                               # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
-                               # path, parent_tag_id, remote_id
+        -
+            identifier: referenceId # A string used to identify the reference
+            attribute: attributeId # The attribute to get the value of for the reference
+                                   # supports: always_available, depth, main_language_code, main_tag_id, modification_date,
+                                   # path, parent_tag_id, remote_id


### PR DESCRIPTION
Without the array structure in references you get the following error on migrations with tags : `Illegal string offset 'attribute' in file /var/www/interpol/vendor/kaliop/ezmigrationbundle/Core/Executor/RepositoryExecutor.php line 169`

Note : I also cleaned the comments about deletion in the update block