### PR TITLE
Update dsl documentation

### DIFF
--- a/Resources/doc/DSL/ContentTypes.yml
+++ b/Resources/doc/DSL/ContentTypes.yml
@@ -44,6 +44,7 @@
 #    field-settings:
 #        selectionMethod: 0 # 1=drop-down list
 #        selectionRoot: null # location id
+#        selectionContentTypes: [ ] # array of ContentType identifiers; works since eZ Platform v1.11.0
 #
 # ezobjectrelationlist
 #    field-settings:


### PR DESCRIPTION
Since v1.11.0 it is possible to restrict selectable content types for single object relations fields: https://doc.ezplatform.com/en/1.12/releases/ez_platform_v1.11.0/

So `ezobjectrelation` accepts the `selectionContentTypes` option too, like `ezobjectrelationlist`. 

No code changes needed for kaliop for this.