### PR TITLE
Fix to add multiple tags in attribute via reference

### DIFF
--- a/Core/FieldHandler/EzTags.php
+++ b/Core/FieldHandler/EzTags.php
@@ -34,7 +34,13 @@ class EzTags extends AbstractFieldHandler implements FieldValueImporterInterface
             $identifier = reset($def);
             $type = key($def);
 
-            $identifier = $this->referenceResolver->resolveReference($identifier);
+            if(is_array($identifier)) {
+                foreach($identifier as $key => $id) {
+                    $identifier[$key] = $this->referenceResolver->resolveReference($id);
+                }
+            } else {
+                $identifier = $this->referenceResolver->resolveReference($identifier);
+            }
 
             foreach ($this->tagMatcher->match(array($type => $identifier)) as $id => $tag) {
                 $tags[$id] = $tag;


### PR DESCRIPTION
This allows to add multiple tags at once with references in an attribute.
Without this, adding multiple tags does not work if one or several of the tags are added via reference, as it does not resolve each reference and throws a NotFoundException when trying to save the attribute.