### PR TITLE
Update ezobjectrelationlist dsl

### DIFF
--- a/Resources/doc/DSL/ContentTypes.yml
+++ b/Resources/doc/DSL/ContentTypes.yml
@@ -51,6 +51,9 @@
 #        selectionMethod: 0 # 1=drop-down list
 #        selectionDefaultLocation: 2
 #        selectionContentTypes: [ ] # array of ContentType identifiers
+#    validator-configuration: # since eZ Platform v2.0
+#        RelationListValueValidator:
+#            selectionLimit: 1 # you can specify how many elements can be selected maximum
 #
 # ezselection
 #    field-settings:


### PR DESCRIPTION
eZ 2 introduced a configurable limit for the `ezobjectrelationlist` field type. Kaliop already can configure this limit, just need this doc update to make it clear. No other changes needed for this, but only works from eZ 2.0 aka kernel 7.0.0.

https://github.com/ezsystems/ezpublish-kernel/blob/v7.0.0/eZ/Publish/Core/FieldType/RelationList/Type.php#L51