### PR TITLE
allow version 4 for nikic php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-pdo": "*",
         "ezsystems/ezpublish-kernel": ">=5.4|>=2014.11",
         "mtdowling/jmespath.php": "2.*",
-        "nikic/php-parser": "^2.0 || ^3.0",
+        "nikic/php-parser": "^2.0 || ^3.0 || ^4.0",
         "symfony/process": "*",
         "symfony/swiftmailer-bundle": "*",
         "symfony/validator": "*",


### PR DESCRIPTION
i'm playing with some other projects that requires this php-parser version. 

do you think this could lead to some problems here? if so, please discard this. 