### PR TITLE
add symfony 3.4.12 as conflicting version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     },
     "conflict": {
         "netgen/tagsbundle": "1.*",
-        "ezsystems/ezpublish-kernel": "6.7.3"
+        "ezsystems/ezpublish-kernel": "6.7.3",
+        "symfony/symfony": "3.4.12"
     },
     "autoload": {
         "psr-4": { "Kaliop\\eZMigrationBundle\\": "" }


### PR DESCRIPTION
let's try adding this symfony version as conflicting one. i tried it locally and test seemed to pass. let's open this pr to see what travis thinks. 