### PR TITLE
fix travis testing by changing orders of the bundles

### DIFF
--- a/Tests/travis/setup-config.sh
+++ b/Tests/travis/setup-config.sh
@@ -21,8 +21,8 @@ sed -i 's/$bundles = array(/$bundles = array(new Kaliop\\eZMigrationBundle\\EzMi
 sed -i 's/$bundles = \[/$bundles = \[new Kaliop\\eZMigrationBundle\\EzMigrationBundle(),/' ${APP_DIR}/${EZ_KERNEL}.php
 # And optionally the Netgen tags bundle
 if [ "$INSTALL_TAGSBUNDLE" = "1" ]; then
-    # we have to load netgen tags bundle after the Kernel bundles... hopefully OneupFlysystemBundle will stay there :-)
-    sed -i 's/OneupFlysystemBundle(),\?/OneupFlysystemBundle(), new Netgen\\TagsBundle\\NetgenTagsBundle(),/' ${APP_DIR}/${EZ_KERNEL}.php
+    # we have to load netgen tags bundle after the Kernel bundles... so we add it before the app bundle :-)
+    sed -i '/AppBundle()/i new Netgen\\TagsBundle\\NetgenTagsBundle(),' ${APP_DIR}/${EZ_KERNEL}.php
 fi
 # And optionally the EzCoreExtraBundle bundle
 #if grep -q 'lolautruche/ez-core-extra-bundle' composer.lock; then


### PR DESCRIPTION
i found that the error we were getting in the test was because when it tried to validate the eztags field added in the migration, the `Null/Type` were used instead of the netgen tags validator. 

Without digging in much more details, i decided to try to move the load of the netgen tags bundle after tall the ez systems bundles. in fact, there was a comment there saying that was the idea, but the result was that the Netgen Bundle was before the ezsystems one in the generated AppKernel. 

This makes the test pass in my computer, php 7.2. I hope not break anything with this, but let's see what travis says... 