### PR TITLE
Fix for mismatched typehint declarations

### DIFF
--- a/Core/Matcher/AbstractMatcher.php
+++ b/Core/Matcher/AbstractMatcher.php
@@ -33,7 +33,7 @@ abstract class AbstractMatcher implements MatcherInterface
         }
     }
 
-    protected function matchAnd($conditionsArray)
+    protected function matchAnd(array $conditionsArray)
     {
         /// @todo introduce proper re-validation of all child conditions
         if (!is_array($conditionsArray) || !count($conditionsArray)) {


### PR DESCRIPTION
See [Issue 179](https://github.com/kaliop-uk/ezmigrationbundle/issues/179) (& [PR 180](https://github.com/kaliop-uk/ezmigrationbundle/pull/180))