### PR TITLE
Allow usergroup_id matching for users

### DIFF
--- a/Core/Matcher/UserMatcher.php
+++ b/Core/Matcher/UserMatcher.php
@@ -19,6 +19,7 @@ class UserMatcher extends RepositoryMatcher implements KeyMatcherInterface
     protected $allowedConditions = array(
         self::MATCH_AND, self::MATCH_OR,
         self::MATCH_USER_ID, self::MATCH_USER_LOGIN, self::MATCH_USER_EMAIL,
+        self::MATCH_USERGROUP_ID,
         // aliases
         'id'
     );


### PR DESCRIPTION
The logic was already implemented, but it wasn't added to the list of allowedConditions.