### PR TITLE
Added note for hashing passwords in kaliop migrations

### DIFF
--- a/Resources/doc/DSL/UsersAndGroups.yml
+++ b/Resources/doc/DSL/UsersAndGroups.yml
@@ -79,7 +79,7 @@
         #                last_name: "faker: lastName"
 
     email: xyz # Optional. NB: can only be set if the match definition latches a single user
-    password: xyz # Optional
+    password: xyz # Optional. NB: The given password string will be automatically hashed.
     enabled: true|false # Optional
     # Optional, Group ID / list of group IDs (or its/their remote_ids) the user has to be a member of.
     # The user will be removed from all groups that are not in the list


### PR DESCRIPTION
Hey,

I stumbled over the fact, that the given password string in a kaliop migration will be automatically hashed. I think this should be mentioned in the docs so here is the change.