### PR TITLE
Fixes for EzPlatform 3.0

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -129,7 +129,7 @@ parameters:
 services:
 
     ez_migration_bundle.migration_service:
-        #public: true
+        public: true
         class: '%ez_migration_bundle.migration_service.class%'
         arguments:
             - '@ez_migration_bundle.loader'
@@ -785,7 +785,7 @@ services:
 
     # This service is used for the verbose mode when executing migrations on the command line
     ez_migration_bundle.step_executed_listener.tracing:
-        #public: true
+        public: true
         class: '%ez_migration_bundle.step_executed_listener.tracing.class%'
         arguments:
             - '%ez_migration_bundle.enable_debug_output%'


### PR DESCRIPTION
Fixes for EzPlatform 3.0

fixes for:
```                                                                
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]   
  The "ez_migration_bundle.migration_service" service or alias has been remov  
  ed or inlined when the container was compiled. You should either make it pu  
  blic, or stop using the container directly and use dependency injection ins  
  tead. 

  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]   
  The "ez_migration_bundle.step_executed_listener.tracing" service or alias h  
  as been removed or inlined when the container was compiled. You should eith  
  er make it public, or stop using the container directly and use dependency   
  injection instead.  
```
which occurs during ezp-ee-demo installer