### PR TITLE
[ezp-3] Fixed Bundle name

### DIFF
--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -20,7 +20,7 @@ class GenerateCommand extends AbstractCommand
     private $availableMigrationFormats = array('yml', 'php', 'sql', 'json');
     private $availableModes = array('create', 'update', 'delete');
     private $availableTypes = array('content', 'content_type', 'content_type_group', 'language', 'object_state', 'object_state_group', 'role', 'section', 'generic', 'db', 'php', '...');
-    private $thisBundle = 'EzMigrationBundle';
+    private $thisBundle = 'eZMigrationBundle';
 
     protected $eventName = 'ez_migration.migration_generated';
 

--- a/DependencyInjection/eZMigrationExtension.php
+++ b/DependencyInjection/eZMigrationExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class EzMigrationExtension extends Extension
+class eZMigrationExtension extends Extension
 {
     public static $loadTestConfig = false;
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `registerBundles` method should look similar to:
     {
         $bundles = array(
             ... more stuff here ...
-            new \Kaliop\eZMigrationBundle\EzMigrationBundle()
+            new \Kaliop\eZMigrationBundle\eZMigrationBundle()
         );
     }
 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -7,4 +7,4 @@ if (!file_exists($file = __DIR__.'/../vendor/autoload.php') && !file_exists($fil
 
 $loader = require $file;
 
-Kaliop\eZMigrationBundle\DependencyInjection\EzMigrationExtension::$loadTestConfig = true;
+Kaliop\eZMigrationBundle\DependencyInjection\eZMigrationExtension::$loadTestConfig = true;

--- a/Tests/config/common/services.yml
+++ b/Tests/config/common/services.yml
@@ -1,6 +1,6 @@
 
 # NB: These services have to be loaded for the test suite to work. They should not be loaded for normal bundle operation
-# The EzMigrationExtension class will take care of loading them automatically as long as the bootstrap.php file is run
+# The eZMigrationExtension class will take care of loading them automatically as long as the bootstrap.php file is run
 
 parameters:
     test.param.for.custom.refs: def

--- a/Tests/environment/setup-ez-config.sh
+++ b/Tests/environment/setup-ez-config.sh
@@ -57,10 +57,10 @@ if [ -f Tests/config/${EZ_VERSION}/ezplatform.yml ]; then
 fi
 
 # Load the migration bundle in the Sf kernel
-fgrep -q 'new Kaliop\eZMigrationBundle\EzMigrationBundle()' ${KERNEL_DIR}/${EZ_KERNEL}.php
+fgrep -q 'new Kaliop\eZMigrationBundle\eZMigrationBundle()' ${KERNEL_DIR}/${EZ_KERNEL}.php
 if [ $? -ne 0 ]; then
-    sed -i 's/$bundles = array(/$bundles = array(new Kaliop\\eZMigrationBundle\\EzMigrationBundle(),/' ${KERNEL_DIR}/${EZ_KERNEL}.php
-    sed -i 's/$bundles = \[/$bundles = \[new Kaliop\\eZMigrationBundle\\EzMigrationBundle(),/' ${KERNEL_DIR}/${EZ_KERNEL}.php
+    sed -i 's/$bundles = array(/$bundles = array(new Kaliop\\eZMigrationBundle\\eZMigrationBundle(),/' ${KERNEL_DIR}/${EZ_KERNEL}.php
+    sed -i 's/$bundles = \[/$bundles = \[new Kaliop\\eZMigrationBundle\\eZMigrationBundle(),/' ${KERNEL_DIR}/${EZ_KERNEL}.php
 fi
 
 # And optionally the EzCoreExtraBundle bundle

--- a/eZMigrationBundle.php
+++ b/eZMigrationBundle.php
@@ -6,7 +6,7 @@ use Kaliop\eZMigrationBundle\DependencyInjection\CompilerPass\TaggedServicesComp
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class EzMigrationBundle extends Bundle
+class eZMigrationBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {


### PR DESCRIPTION
Bundle name should follow naming convention https://symfony.com/doc/current/bundles/best_practices.html#bundle-name

The issue occurs when trying to install this bundle on sf4 using symfony flex,

https://github.com/symfony/flex/blob/master/src/SymfonyBundle.php#L89
https://github.com/symfony/flex/blob/master/src/SymfonyBundle.php#L103

code expects that the bundle file will follow
namespace  "Kaliop\eZMigrationBundle\" -> one of those:

  0 => "Kaliop\eZMigrationBundle\eZMigrationBundle"
  1 => "Kaliop\eZMigrationBundle\KaliopeZMigrationBundle"


related issues 
```
!!                                                                                 
!!    Case mismatch between loaded and declared class names: "Kaliop\eZMigrationB  
!!    undle\DependencyInjection\eZMigrationExtension" vs "Kaliop\eZMigrationBundl  
!!    e\DependencyInjection\EzMigrationExtension".                                 
!!         

!!                                                                           
!!    Trying to register two bundles with the same name "EzMigrationBundle"  
!!      
```

