### PR TITLE
issue-224: add support for ezcountry field

### DIFF
--- a/Core/FieldHandler/EzCountry.php
+++ b/Core/FieldHandler/EzCountry.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kaliop\eZMigrationBundle\Core\FieldHandler;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\Core\FieldType\Country\Value as CountryValue;
+use eZ\Publish\Core\FieldType\Selection\Value as SelectionValue;
+use Kaliop\eZMigrationBundle\API\FieldValueImporterInterface;
+
+class EzCountry extends AbstractFieldHandler implements FieldValueImporterInterface
+{
+    private $contentTypeService;
+
+    private $fieldTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService, FieldTypeService $fieldTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
+    /**
+     * Creates a value object to use as the field value when setting a country field type.
+     *
+     * @param $fieldValue string|string[] should work
+     * @param array $context The context for execution of the current migrations. $hashValueContains f.e. the path to the migration
+     * @return CountryValue
+     */
+    public function hashToFieldValue($fieldValue, array $context = array())
+    {
+        if ($fieldValue === null) {
+            return new CountryValue();
+        }
+
+        if (is_string($fieldValue)) {
+            $fieldValue = array($fieldValue);
+        }
+
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($context['contentTypeIdentifier']);
+        $field = $contentType->getFieldDefinition($context['fieldIdentifier']);
+        $fieldType = $this->fieldTypeService->getFieldType($field->fieldTypeIdentifier);
+
+        return $fieldType->fromHash($fieldValue);
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -99,6 +99,7 @@ parameters:
     ez_migration_bundle.complex_field.ezauthor.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzAuthor
     ez_migration_bundle.complex_field.ezbinaryfile.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzBinaryFile
     ez_migration_bundle.complex_field.ezboolean.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzBoolean
+    ez_migration_bundle.complex_field.country.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzCountry
     ez_migration_bundle.complex_field.ezdate.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzDate
     ez_migration_bundle.complex_field.ezdatetime.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzDateAndTime
     ez_migration_bundle.complex_field.ezimage.class: Kaliop\eZMigrationBundle\Core\FieldHandler\EzImage
@@ -629,6 +630,15 @@ services:
         class: '%ez_migration_bundle.complex_field.ezboolean.class%'
         tags:
             - { name: ez_migration_bundle.complex_field, fieldtype: ezboolean, priority: 0 }
+
+    ez_migration_bundle.complex_field.ezcountry:
+        parent: ez_migration_bundle.complex_field
+        class: '%ez_migration_bundle.complex_field.country.class%'
+        arguments:
+            - '@ezpublish.api.service.content_type'
+            - '@ezpublish.api.service.field_type'
+        tags:
+            - { name: ez_migration_bundle.complex_field, fieldtype: ezcountry, priority: 0 }
 
     ez_migration_bundle.complex_field.ezdate:
         parent: ez_migration_bundle.complex_field

--- a/Resources/doc/DSL/Contents.yml
+++ b/Resources/doc/DSL/Contents.yml
@@ -68,6 +68,10 @@
         attribute15: [ 1, "option 2" ] # array of selection options ids or textual values
         # ezselection, single value
         attribute16: "option 3" # integer index or string
+        # ezcountry, multiple values
+        attribute17: [IT, ESP, 41, Taiwan] # Either Alpha2, Alpha3, IDC or Name array of the countries, as defined in %ezpublish.fieldType.ezcountry.data%'
+        # ezcountry, single value
+        attribute18: IT # allows also 'ITA', '39' and 'Italy'. Either Alpha2, Alpha3, IDC or Name of the country, as defined in %ezpublish.fieldType.ezcountry.data%'
     always_available: true|false # Optional, will default to content type defaultAlwaysAvailable
     is_hidden: true|false # Optional
     lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)

--- a/Resources/doc/DSL/Contents.yml
+++ b/Resources/doc/DSL/Contents.yml
@@ -68,10 +68,8 @@
         attribute15: [ 1, "option 2" ] # array of selection options ids or textual values
         # ezselection, single value
         attribute16: "option 3" # integer index or string
-        # ezcountry, multiple values
-        attribute17: [IT, ESP, 41, Taiwan] # Either Alpha2, Alpha3, IDC or Name array of the countries, as defined in %ezpublish.fieldType.ezcountry.data%'
-        # ezcountry, single value
-        attribute18: IT # allows also 'ITA', '39' and 'Italy'. Either Alpha2, Alpha3, IDC or Name of the country, as defined in %ezpublish.fieldType.ezcountry.data%'
+        # ezcountry
+        attribute17: [IT, ESP, 41, Taiwan] # Either Alpha2, Alpha3, IDC or Name array of the countries, as defined in %ezpublish.fieldType.ezcountry.data%'. A single value can be provided also as string
     always_available: true|false # Optional, will default to content type defaultAlwaysAvailable
     is_hidden: true|false # Optional
     lang: xxx-YY # Optional, will fallback to default language if not provided (--default-language option or 'eng-GB' by default)

--- a/Tests/dsl/good/UnitTestOK004_content.yml
+++ b/Tests/dsl/good/UnitTestOK004_content.yml
@@ -336,7 +336,6 @@
             - Afghanistan
             - AX
             - ALB
-            - 34 # Spain IDC
         - ezobjectrelation:
             destinationContentId: 'reference:kmb_test_004_1'
         - ezobjectrelationlist:

--- a/Tests/dsl/good/UnitTestOK004_content.yml
+++ b/Tests/dsl/good/UnitTestOK004_content.yml
@@ -336,6 +336,7 @@
             - Afghanistan
             - AX
             - ALB
+            - 34 # Spain IDC
         - ezobjectrelation:
             destinationContentId: 'reference:kmb_test_004_1'
         - ezobjectrelationlist:


### PR DESCRIPTION
Adds support for ez country field allowing entering either a single alpha2 (for non multiple calues cases) or an array of codes for the case the field allows multiple values