### PR TITLE
Fix compiling error

### DIFF
--- a/Core/ReferenceResolver/EmbeddedRegexpReferenceResolverTrait.php
+++ b/Core/ReferenceResolver/EmbeddedRegexpReferenceResolverTrait.php
@@ -86,5 +86,5 @@ trait EmbeddedRegexpReferenceResolverTrait
      * @param string $stringIdentifier
      * @return mixed
      */
-    abstract protected function getReferenceValue($stringIdentifier);
+    abstract public function getReferenceValue($stringIdentifier);
 }


### PR DESCRIPTION
I have this error on PHP7.4 with Symfony 3.4.37
```
Compile Error: Access level to Kaliop\eZMigrationBundle\Core\ReferenceResolver\EmbeddedRegexpReferenceResolverTrait::getR  
  eferenceValue() must be public (as in class Kaliop\eZMigrationBundle\Core\ReferenceResolver\PrefixBasedResolver)
```