### PR TITLE
fix: backport fix to issue #232 to bundle version 5.7

### DIFF
--- a/Core/ReferenceResolver/EmbeddedRegexpReferenceResolverTrait.php
+++ b/Core/ReferenceResolver/EmbeddedRegexpReferenceResolverTrait.php
@@ -20,7 +20,7 @@ trait EmbeddedRegexpReferenceResolverTrait
         $regexp = $this->getEmbeddedRegexp();
         return (bool) preg_match_all($regexp, $string, $matches);
     }
-    
+
     /**
      * Returns the $string with eventual refs resolved
      *
@@ -79,12 +79,12 @@ trait EmbeddedRegexpReferenceResolverTrait
      * Has to be implemented in the class which uses this trait
      * @return string
      */
-    abstract protected function getRegexp();
+    abstract public function getRegexp();
 
     /**
      * Has to be implemented in the class which uses this trait
      * @param string $stringIdentifier
      * @return mixed
      */
-    abstract protected function getReferenceValue($stringIdentifier);
+    abstract public function getReferenceValue($stringIdentifier);
 }


### PR DESCRIPTION
this backports the fix to issue #232 to version 5.7 of the bundle (which works correctly with ezworkflowengine bundle), it should be tagged as 5.7.4 if the PR is accepted.